### PR TITLE
Ensure physical min/max are always rounded down/up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+- When `EdfSignal.physical_min` or `EdfSignal.physical_max` do not fit into their header fields, they are now always rounded down or up, respectively, to ensure all physical values lie within the physical range ([#2](https://github.com/the-siesta-group/edfio/pull/2)).
+
+
 ## [0.1.0] - 2023-11-09
 
 Initial release 🎉

--- a/edfio/_header_field.py
+++ b/edfio/_header_field.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import math
 import re
-import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Any, Generic, TypeVar, overload
@@ -30,20 +29,9 @@ def encode_int(value: int, length: int) -> bytes:
 
 
 def encode_float(value: float, length: int) -> bytes:
-    value_str = str(value)
-    if len(value_str) > length:
-        integer_part_length = len(str(int(value)))
-        if value < 0 and int(value) == 0:
-            integer_part_length = 2
-        if integer_part_length > length:
-            raise ValueError(f"{value} exceeds maximum field length {length}")
-        if integer_part_length == length:
-            value_str = f"{value:.0f}"
-        else:
-            value_str = f"{value:.{length-1-integer_part_length}f}"
-        msg = f"{value} exceeds maximum field length {length}, rounding to {value_str}"
-        warnings.warn(msg)
-    return encode_str(value_str, length)
+    if float(value).is_integer():
+        value = int(value)
+    return encode_str(str(value), length)
 
 
 def decode_float(field: bytes) -> float:

--- a/edfio/_utils.py
+++ b/edfio/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import inspect
-from typing import Any, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 
 def calculate_gain_and_offset(
@@ -76,3 +76,15 @@ def encode_annotation_duration(duration: float) -> str:
     if string[-1] == ".":
         return string[:-1]
     return string
+
+
+def round_float_to_8_characters(
+    value: float,
+    round_func: Callable[[float], int],
+) -> float:
+    length = 8
+    integer_part_length = str(value).find(".")
+    if integer_part_length == length:
+        return round_func(value)
+    factor = 10 ** (length - 1 - integer_part_length)
+    return round_func(value * factor) / factor

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -955,4 +955,5 @@ def test_rounding_of_physical_range_does_not_produce_clipping_or_integer_overflo
     data = np.array([0, 0.0000014999])
     sig = EdfSignal(data, 1)
     np.testing.assert_allclose(sig.data, data, atol=1e-11)
+    # round((0.0000014999 - 0.0) / 0.000002 * 65535 + (-32768)) = 16380
     assert sig._digital.tolist() == [-32768, 16380]

--- a/tests/test_header_field.py
+++ b/tests/test_header_field.py
@@ -30,23 +30,6 @@ def test_encode_float(value: float, expected: bytes):
     assert encode_float(value, 8) == expected
 
 
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (0.12345678, b"0.123457"),
-        (1.23456789, b"1.234568"),
-        (12345.6789, b"12345.68"),
-        (1234567.8, b"1234568 "),
-        (12345678.9, b"12345679"),
-        (-0.987654321, b"-0.98765"),
-        (-0.444444, b"-0.44444"),
-    ],
-)
-def test_encode_float_requiring_rounding(value: float, expected: bytes):
-    with pytest.warns(UserWarning, match="exceeds maximum field length 8, rounding"):
-        assert encode_float(value, 8) == expected
-
-
 @pytest.mark.parametrize("field", [b"1E2345  ", b"-1E2345 "])
 def test_decode_float_exceeding_float_range_fails(field: bytes):
     with pytest.raises(ValueError, match="outside float range"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 
 import pytest
 
@@ -7,6 +8,7 @@ from edfio._utils import (
     encode_annotation_duration,
     encode_annotation_onset,
     encode_edfplus_date,
+    round_float_to_8_characters,
 )
 
 VALID_EDFPLUS_DATE_PAIRS = (
@@ -80,3 +82,45 @@ def test_encode_annotation_duration(duration: float, expected: str):
 def test_encode_annotation_duration_raises_error_for_negative_values():
     with pytest.raises(ValueError, match="Annotation duration must be positive, is"):
         encode_annotation_duration(-1)
+
+
+# fmt: off
+@pytest.mark.parametrize(
+    (   "value",       "expected_round", "expected_floor", "expected_ceil"),
+    [
+        (1.1111114,     1.111111,         1.111111,         1.111112,),
+        (1.111111444,   1.111111,         1.111111,         1.111112,),
+        (1.111111499,   1.111111,         1.111111,         1.111112,),
+        (1.1111115,     1.111112,         1.111111,         1.111112,),
+        (1111111.4,     1111111,          1111111,          1111112,),
+        (1111111.444,   1111111,          1111111,          1111112,),
+        (1111111.499,   1111111,          1111111,          1111112,),
+        (1111111.5,     1111112,          1111111,          1111112,),
+        (11111111.4,    11111111,         11111111,         11111112,),
+        (11111111.444,  11111111,         11111111,         11111112,),
+        (11111111.499,  11111111,         11111111,         11111112,),
+        (11111111.5,    11111112,         11111111,         11111112,),
+        (-1.111114,     -1.11111,         -1.11112,         -1.11111,),
+        (-1.11111444,   -1.11111,         -1.11112,         -1.11111,),
+        (-1.11111499,   -1.11111,         -1.11112,         -1.11111,),
+        (-1.111115,     -1.11112,         -1.11112,         -1.11111,),
+        (-111111.4,     -111111,          -111112,          -111111,),
+        (-111111.444,   -111111,          -111112,          -111111,),
+        (-111111.499,   -111111,          -111112,          -111111,),
+        (-111111.5,     -111112,          -111112,          -111111,),
+        (-1111111.4,    -1111111,         -1111112,         -1111111,),
+        (-1111111.444,  -1111111,         -1111112,         -1111111,),
+        (-1111111.499,  -1111111,         -1111112,         -1111111,),
+        (-1111111.5,    -1111112,         -1111112,         -1111111,),
+    ],
+)
+# fmt: on
+def test_round_float_to_8_characters(
+    value: float,
+    expected_round: float,
+    expected_floor: float,
+    expected_ceil: float,
+):
+    assert round_float_to_8_characters(value, round) == expected_round
+    assert round_float_to_8_characters(value, math.floor) == expected_floor
+    assert round_float_to_8_characters(value, math.ceil) == expected_ceil


### PR DESCRIPTION
Currently, `physical_min` and `physical_max` are rounded via string formatting when writing them to their respective header fields, to fit the 8 character limit. This can lead to a situation where e.g. `physical_max` is rounded _down_, making it smaller than some actual (physical) signal values. Always rounding `physical_min` _down_ and `physical_max` _up_ ensures that all signal values lie within the physical range. This should make clipping the digital values to the digital range in `EdfSignal._set_data` obsolete and thereby close #1.