### PR TITLE
Add fallback for calculation of num_data_records to avoid floating point errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 - When `EdfSignal.physical_min` or `EdfSignal.physical_max` do not fit into their header fields, they are now always rounded down or up, respectively, to ensure all physical values lie within the physical range ([#2](https://github.com/the-siesta-group/edfio/pull/2)).
 
+### Fixed
+- The calculation of `num_data_records` from signal duration and `data_record_duration` is now more robust to floating point errors ([#3](https://github.com/the-siesta-group/edfio/pull/3))
+
 
 ## [0.1.0] - 2023-11-09
 

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -9,6 +9,7 @@ import re
 import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from decimal import Decimal
 from fractions import Fraction
 from functools import singledispatch
 from pathlib import Path
@@ -1327,12 +1328,13 @@ def _calculate_num_data_records(
         raise ValueError(
             f"data_record_duration must be positive, got {data_record_duration}"
         )
-    required_num_data_records = signal_duration / data_record_duration
-    if required_num_data_records != int(required_num_data_records):
-        raise ValueError(
-            f"Signal duration of {signal_duration}s is not exactly divisible by data_record_duration of {data_record_duration}s"
-        )
-    return int(required_num_data_records)
+    for f in (lambda x: x, lambda x: Decimal(str(x))):
+        required_num_data_records = f(signal_duration) / f(data_record_duration)
+        if required_num_data_records == int(required_num_data_records):
+            return int(required_num_data_records)
+    raise ValueError(
+        f"Signal duration of {signal_duration}s is not exactly divisible by data_record_duration of {data_record_duration}s"
+    )
 
 
 def _calculate_data_record_duration(signals: Sequence[EdfSignal]) -> float:


### PR DESCRIPTION
Currently, creating a new Edf with e.g. 8001 samples at 1000Hz and a `data_record_duration` of 0.001 fails, even though the signal duration of 8.001 would be divisible by 0.001. This PR introduces a fallback using [`decimal.Decimal`](https://docs.python.org/3/library/decimal.html#decimal.Decimal) to make the calculation of `num_data_records` more robust.