### PR TITLE
Replace invalid characters in string decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - When `EdfSignal.physical_min` or `EdfSignal.physical_max` do not fit into their header fields, they are now always rounded down or up, respectively, to ensure all physical values lie within the physical range ([#2](https://github.com/the-siesta-group/edfio/pull/2)).
+- Support non-standard header fields (not encoded as UTF-8) by replacing incompatible characters with "�" ([#4](https://github.com/the-siesta-group/edfio/pull/4)).
 
 
 ## [0.1.0] - 2023-11-09

--- a/edfio/_header_field.py
+++ b/edfio/_header_field.py
@@ -21,7 +21,7 @@ def encode_str(value: str, length: int) -> bytes:
 
 
 def decode_str(field: bytes) -> str:
-    return field.decode().rstrip()
+    return field.decode(errors="replace").rstrip()
 
 
 def encode_int(value: int, length: int) -> bytes:

--- a/tests/test_header_field.py
+++ b/tests/test_header_field.py
@@ -3,6 +3,7 @@ import pytest
 from edfio._header_field import (
     RawHeaderFieldDate,
     decode_float,
+    decode_str,
     encode_float,
     encode_int,
 )
@@ -28,6 +29,11 @@ def test_encode_float_exceeding_field_length_fails():
 )
 def test_encode_float(value: float, expected: bytes):
     assert encode_float(value, 8) == expected
+
+
+def test_decode_str():
+    assert decode_str("è".encode("latin-1")) == "�"
+    assert decode_str("è".encode()) == "è"
 
 
 @pytest.mark.parametrize("field", [b"1E2345  ", b"-1E2345 "])


### PR DESCRIPTION
According to the EDF standard, header fields can only contain (printable) ASCII characters. edfio relaxes this constraint to UTF-8 upon reading, which enables the package to read non-standard EDF files (which are very common in the wild).

However, it might still be the case that people populate header fields with other encodings (such as Latin-1) that are incompatible with UTF-8. For example:

```python
>>> "é".encode("latin1").decode()
UnicodeDecodeError
```

This PR adds the `errors="replace"` argument, which adds support for all non-UTF-8 characters, but replaces them with `�`.

```python
>>> "é".encode("latin1").decode(errors="replace")
'�'
```