### PR TITLE
Refuse empty subfields in local patient/recording identification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).
+
 ## [0.2.1] - 2023-11-17
 
 ### Fixed

--- a/edfio/_utils.py
+++ b/edfio/_utils.py
@@ -88,3 +88,11 @@ def round_float_to_8_characters(
         return round_func(value)
     factor = 10 ** (length - 1 - integer_part_length)
     return round_func(value * factor) / factor
+
+
+def validate_subfields(subfields: dict[str, str]) -> None:
+    for key, value in subfields.items():
+        if not value:
+            raise ValueError(f"Subfield {key} must not be an empty string")
+        if " " in value:
+            raise ValueError(f"Subfield {key} contains spaces: {value!r}")

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -37,6 +37,7 @@ from edfio._utils import (
     encode_edfplus_date,
     repr_from_init,
     round_float_to_8_characters,
+    validate_subfields,
 )
 
 _ANNOTATIONS_PATTERN = re.compile(
@@ -365,11 +366,10 @@ class Patient:
             "sex": sex,
             "birthdate": birthdate_field,
             "name": name,
+            **{f"additional[{i}]": v for i, v in enumerate(additional)},
         }
-        for key, value in subfields.items():
-            if " " in value:
-                raise ValueError(f"Subfield {key} contains spaces: {value!r}")
-        local_patient_identification = " ".join((*subfields.values(), *additional))
+        validate_subfields(subfields)
+        local_patient_identification = " ".join(subfields.values())
         encode_str(local_patient_identification, 80)
         self._local_patient_identification = local_patient_identification
 
@@ -460,17 +460,10 @@ class Recording:
             "hospital_administration_code": hospital_administration_code,
             "investigator_technician_code": investigator_technician_code,
             "equipment_code": equipment_code,
+            **{f"additional[{i}]": v for i, v in enumerate(additional)},
         }
-        for key, value in subfields.items():
-            if " " in value:
-                raise ValueError(f"Subfield {key} contains spaces: {value!r}")
-        local_recording_identification = " ".join(
-            (
-                "Startdate",
-                *subfields.values(),
-                *additional,
-            )
-        )
+        validate_subfields(subfields)
+        local_recording_identification = " ".join(("Startdate", *subfields.values()))
         encode_str(local_recording_identification, 80)
         self._local_recording_identification = local_recording_identification
 

--- a/tests/test_edfplus_header.py
+++ b/tests/test_edfplus_header.py
@@ -322,3 +322,49 @@ def test_edf_startdate_falls_back_to_legacy_field_if_recording_field_is_not_vali
     edf = Edf([EdfSignal(np.arange(10), 1)], recording=Recording(startdate=startdate))
     edf._local_recording_identification = local_recording_identification.ljust(80)
     assert edf.startdate == startdate
+
+
+@pytest.mark.parametrize(
+    ("code", "name", "additional"),
+    [
+        ("", "X", ()),
+        ("X", "", ()),
+        ("X", "X", ("add1", "", "add2")),
+    ],
+)
+def test_patient_raises_error_on_empty_subfields(
+    code: str,
+    name: str,
+    additional: tuple[str, ...],
+):
+    with pytest.raises(ValueError, match="must not be an empty string"):
+        Patient(code=code, name=name, additional=additional)
+
+
+@pytest.mark.parametrize(
+    (
+        "hospital_administration_code",
+        "investigator_technician_code",
+        "equipment_code",
+        "additional",
+    ),
+    [
+        ("", "X", "X", ()),
+        ("X", "", "X", ()),
+        ("X", "X", "", ()),
+        ("X", "X", "X", ("add1", "", "add2")),
+    ],
+)
+def test_recording_raises_error_on_empty_subfields(
+    hospital_administration_code: str,
+    investigator_technician_code: str,
+    equipment_code: str,
+    additional: tuple[str, ...],
+):
+    with pytest.raises(ValueError, match="must not be an empty string"):
+        Recording(
+            hospital_administration_code=hospital_administration_code,
+            investigator_technician_code=investigator_technician_code,
+            equipment_code=equipment_code,
+            additional=additional,
+        )


### PR DESCRIPTION
Instantiating `Patient` and `Recording` should raise an error if any of the passed string subfields are empty, to not mess up the structure defined by the EDF+ specs.