### PR TITLE
Allow creating Edf containing only annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Allow creating a new Edf containing only annotations ([#7](https://github.com/the-siesta-group/edfio/pull/7)).
+
 ### Fixed
 - Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).
 


### PR DESCRIPTION
As described in [section 2.1.2](https://www.edfplus.info/specs/edfplus.html#datarecords) of the EDF+ specs, an EDF+ may contain only an annotation signal and no ordinary signals, e.g. to store a hypnogram.