### PR TITLE
Allow getting starttime from EDF+C without annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).
+- Allow retrieving the starttime from a file where the reserved field indicates it is an EDF+C but no annotations signal is present ([#8](https://github.com/the-siesta-group/edfio/pull/8)).
 
 ## [0.2.1] - 2023-11-17
 

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -881,11 +881,12 @@ class Edf:
 
     @property
     def _subsecond_offset(self) -> float:
-        if self.reserved == "EDF+C":
+        try:
             timekeeping_raw = self._timekeeping_signal._digital.tobytes()
             first_data_record = timekeeping_raw[: timekeeping_raw.find(b"\x00") + 1]
             return _EdfAnnotationsDataRecord.from_bytes(first_data_record).tals[0].onset
-        return 0
+        except StopIteration:
+            return 0
 
     @property
     def starttime(self) -> datetime.time:

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1019,3 +1019,13 @@ def test_signals_cannot_be_set_to_empty_sequence_for_edf_without_annotations():
     edf = Edf([EdfSignal(np.arange(2), 1)])
     with pytest.raises(ValueError, match="signals must not be empty"):
         edf.signals = []
+
+
+def test_get_starttime_from_file_with_reserved_field_indicating_edfplus_but_no_annotations_signal(
+    tmp_file: Path,
+):
+    starttime = datetime.time(22, 33, 44)
+    edf = Edf([EdfSignal(np.arange(2), 1)], starttime=starttime)
+    edf._reserved = Edf.reserved.encode("EDF+C")
+    edf.write(tmp_file)
+    assert read_edf(tmp_file).starttime == starttime


### PR DESCRIPTION
Files like this do not comply with the EDF+ specs, but they do exist :D