### PR TITLE
Redesign signals interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Allow creating a new Edf containing only annotations ([#7](https://github.com/the-siesta-group/edfio/pull/7)).
+- Allow setting `EdfSignal.data` with an array of equal length as the existing data ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ### Fixed
 - Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ## [Unreleased]
 ### Changed
-- `Edf.signals` can not be set anymore. Use `Edf.append_signals()`, `Edf.drop_signals()`, and `EdfSignal.data` instead ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
+- `Edf.signals` can not be set anymore. Use `Edf.append_signals()`, `Edf.drop_signals()`, and `EdfSignal.update_data()` instead ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ### Added
 - Allow creating a new Edf containing only annotations ([#7](https://github.com/the-siesta-group/edfio/pull/7)).
-- Allow setting `EdfSignal.data` with an array of equal length as the existing data ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
+- Add `EdfSignal.update_data` for overwriting the physical values with an array of equal length ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 - Allow adding new signals to an Edf with `Edf.append_signals` ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- `Edf.signals` can not be set anymore. Use `Edf.append_signals()`, `Edf.drop_signals()`, and `EdfSignal.data` instead ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ### Added
 - Allow creating a new Edf containing only annotations ([#7](https://github.com/the-siesta-group/edfio/pull/7)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Allow creating a new Edf containing only annotations ([#7](https://github.com/the-siesta-group/edfio/pull/7)).
 - Allow setting `EdfSignal.data` with an array of equal length as the existing data ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
+- Allow adding new signals to an Edf with `Edf.append_signals` ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ### Fixed
 - Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Disallow creating a new Edf where local patient/recording identification subfields are empty strings ([#6](https://github.com/the-siesta-group/edfio/pull/6)).
 - Allow retrieving the starttime from a file where the reserved field indicates it is an EDF+C but no annotations signal is present ([#8](https://github.com/the-siesta-group/edfio/pull/8)).
+- Disallow removing the EDF+ timekeeping signal with `Edf.drop_signals` ([#10](https://github.com/the-siesta-group/edfio/pull/10)).
 
 ## [0.2.1] - 2023-11-17
 

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -277,7 +277,12 @@ class EdfSignal:
         data.setflags(write=False)
         return data
 
-    def update_data(self, data: npt.NDArray[np.float64]) -> None:
+    def update_data(
+        self,
+        data: npt.NDArray[np.float64],
+        *,
+        keep_physical_range: bool = False,
+    ) -> None:
         """
         Overwrite physical signal values with an array of equal length.
 
@@ -285,12 +290,15 @@ class EdfSignal:
         ----------
         data : npt.NDArray[np.float64]
             The new physical data.
+        keep_physical_range : bool, default: False
+            If `True`, the `physical_range` is not modified to accomodate the new data.
         """
         if len(data) != len(self._digital):
             raise ValueError(
                 f"Signal lengths must match: got {len(data)}, expected {len(self._digital)}."
             )
-        self._set_physical_range(None, data)
+        physical_range = self.physical_range if keep_physical_range else None
+        self._set_physical_range(physical_range, data)
         self._set_data(data)
 
     def _set_digital_range(self, digital_range: tuple[int, int]) -> None:

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -982,8 +982,14 @@ class Edf:
             drop = [drop]
         selected: list[EdfSignal] = []
         dropped: list[int | str] = []
+        try:
+            timekeeping_signal = self._timekeeping_signal
+        except StopIteration:
+            timekeeping_signal = None
         for i, signal in enumerate(self.signals):
             if i in drop or signal.label in drop:
+                if signal is timekeeping_signal:
+                    raise ValueError("Can not drop EDF+ timekeeping signal.")
                 dropped.append(i)
                 dropped.append(signal.label)
             else:

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -640,7 +640,7 @@ class Edf:
                 ),
             )
             self._reserved = Edf.reserved.encode("EDF+C")
-        self.signals = tuple(signals)
+        self._set_signals(signals)
 
     def __repr__(self) -> str:
         return repr_from_init(self)
@@ -675,12 +675,12 @@ class Edf:
         All signals contained in the recording, including annotation signals.
 
         Individual signals can not be removed, added, or replaced by modifying this
-        property. However, it can be set to a new sequence of `EdfSignal` objects.
+        property. Use :meth:`Edf.append_signals`, :meth:`Edf.drop_signals`, or
+        :attr:`EdfSignal.data`, respectively.
         """
         return self._signals
 
-    @signals.setter
-    def signals(self, signals: Sequence[EdfSignal]) -> None:
+    def _set_signals(self, signals: Sequence[EdfSignal]) -> None:
         if not signals:
             raise ValueError("signals must not be empty")
         signals = tuple(signals)
@@ -1021,7 +1021,7 @@ class Edf:
         """
         if isinstance(new_signals, EdfSignal):
             new_signals = [new_signals]
-        self.signals = (*self.signals, *new_signals)
+        self._set_signals((*self.signals, *new_signals))
 
     @property
     def _annotation_signals(self) -> Iterable[EdfSignal]:
@@ -1149,7 +1149,7 @@ class Edf:
                 stop_index = stop * signal.sampling_frequency
                 signal._digital = signal._digital[int(start_index) : int(stop_index)]
                 signals.append(signal)
-        self.signals = tuple(signals)
+        self._set_signals(signals)
         self._shift_startdatetime(int(start))
 
     def slice_between_annotations(

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -254,8 +254,10 @@ class EdfSignal:
         """
         Numpy array containing the physical signal values as floats.
 
-        To simplify avoiding inconsistencies between signal data and header fields, this
-        array is non-writable.
+        Can be overwritten with an array of equal length, in which case the physical
+        range is adjusted accordingly. However, to simplify avoiding inconsistencies
+        between signal data and header fields, individual values in the returned array
+        can not be modified.
         """
         try:
             gain, offset = calculate_gain_and_offset(
@@ -275,6 +277,15 @@ class EdfSignal:
             data = (self._digital + offset) * gain
         data.setflags(write=False)
         return data
+
+    @data.setter
+    def data(self, data: npt.NDArray[np.float64]) -> None:
+        if len(data) != len(self._digital):
+            raise ValueError(
+                f"Signal lengths must match: got {len(data)}, expected {len(self._digital)}."
+            )
+        self._set_physical_range(None, data)
+        self._set_data(data)
 
     def _set_digital_range(self, digital_range: tuple[int, int]) -> None:
         digital_range = IntRange(*digital_range)

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -681,8 +681,6 @@ class Edf:
         return self._signals
 
     def _set_signals(self, signals: Sequence[EdfSignal]) -> None:
-        if not signals:
-            raise ValueError("signals must not be empty")
         signals = tuple(signals)
         self._set_num_data_records_with_signals(signals)
         self._signals = signals

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -254,10 +254,9 @@ class EdfSignal:
         """
         Numpy array containing the physical signal values as floats.
 
-        Can be overwritten with an array of equal length, in which case the physical
-        range is adjusted accordingly. However, to simplify avoiding inconsistencies
-        between signal data and header fields, individual values in the returned array
-        can not be modified.
+        To simplify avoiding inconsistencies between signal data and header fields,
+        individual values in the returned array can not be modified. Use
+        :meth:`EdfSignal.update_data` to overwrite with new physical data.
         """
         try:
             gain, offset = calculate_gain_and_offset(
@@ -278,8 +277,15 @@ class EdfSignal:
         data.setflags(write=False)
         return data
 
-    @data.setter
-    def data(self, data: npt.NDArray[np.float64]) -> None:
+    def update_data(self, data: npt.NDArray[np.float64]) -> None:
+        """
+        Overwrite physical signal values with an array of equal length.
+
+        Parameters
+        ----------
+        data : npt.NDArray[np.float64]
+            The new physical data.
+        """
         if len(data) != len(self._digital):
             raise ValueError(
                 f"Signal lengths must match: got {len(data)}, expected {len(self._digital)}."

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1041,3 +1041,25 @@ def test_get_starttime_from_file_with_reserved_field_indicating_edfplus_but_no_a
     edf._reserved = Edf.reserved.encode("EDF+C")
     edf.write(tmp_file)
     assert read_edf(tmp_file).starttime == starttime
+
+
+@pytest.mark.parametrize("selection", [[1], ["EDF Annotations"]])
+def test_drop_signals_does_not_allow_dropping_timekeeping_signal(selection):
+    edf = Edf(
+        signals=[
+            EdfSignal(np.arange(2), sampling_frequency=1),
+            _create_annotations_signal(
+                [EdfAnnotation(0, None, "ann 1")],
+                num_data_records=2,
+                data_record_duration=1,
+            ),
+            _create_annotations_signal(
+                [EdfAnnotation(0.25, None, "ann 2")],
+                num_data_records=2,
+                data_record_duration=1,
+                with_timestamps=False,
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="Can not drop EDF\\+ timekeeping signal"):
+        edf.drop_signals(selection)

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -510,9 +510,21 @@ def test_edf_signal_with_too_small_physical_range_fails():
         EdfSignal(np.arange(10), 1, physical_range=(3, 5))
 
 
-def test_edf_signal_data_is_unsettable(dummy_edf_signal: EdfSignal):
-    with pytest.raises(AttributeError):
-        dummy_edf_signal.data = np.arange(3)
+@pytest.mark.parametrize("data", [[-3, 3], [-3, 7], [-7, 7]])
+def test_edf_signal_data_can_be_set(data):
+    data = np.array(data)
+    signal = EdfSignal(np.array([-5, 5]), 1)
+    signal.data = data
+    np.testing.assert_array_equal(signal.data, data)
+    np.testing.assert_array_equal(signal._digital, np.array([-32768, 32767]))
+    assert signal.physical_range == FloatRange(data.min(), data.max())
+
+
+@pytest.mark.parametrize("length", [9, 11])
+def test_edf_signal_setting_data_fails_on_length_mismatch(length: int):
+    signal = EdfSignal(np.arange(10), 1)
+    with pytest.raises(ValueError, match="Signal lengths must match"):
+        signal.data = np.arange(length)
 
 
 def test_edf_signal_data_cannot_be_modified(dummy_edf_signal: EdfSignal):

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -335,30 +335,6 @@ def test_edf_signal_from_raw_header_has_no_data_by_default():
         sig.data
 
 
-def test_removing_signals_from_edf_sets_bytes_in_header_record_and_num_signals():
-    edf = read_edf(EDF_FILE)
-    edf.signals = edf.signals[:2]
-    assert edf.bytes_in_header_record == 256 * 3
-    assert edf.num_signals == 2
-
-
-def test_overwriting_signals_in_edf_sets_correct_header_fields():
-    signals = [
-        EdfSignal(sine(5, 2, 30), 30, physical_range=(-1, 1)),
-        EdfSignal(sine(5, 2, 20), 20, physical_range=(-1, 1)),
-    ]
-    edf = Edf(signals)
-
-    edf.signals = [
-        EdfSignal(sine(3, 2, 30), 30, physical_range=(-1, 1)),
-        EdfSignal(sine(3, 2, 20), 20, physical_range=(-1, 1)),
-        EdfSignal(sine(3, 2, 10), 10, physical_range=(-1, 1)),
-    ]
-    assert edf.bytes_in_header_record == 256 * 4
-    assert edf.num_signals == 3
-    assert edf.num_data_records == 3
-
-
 def test_read_write_roundtrip(tmp_file: Path):
     edf = read_edf(EDF_FILE)
     edf.write(tmp_file)
@@ -1025,12 +1001,6 @@ def test_edf_with_only_annotations_can_be_written(tmp_file: Path):
 def test_edf_without_signals_or_annotations_cannot_be_created():
     with pytest.raises(ValueError, match="must contain either signals or annotations"):
         Edf([])
-
-
-def test_signals_cannot_be_set_to_empty_sequence_for_edf_without_annotations():
-    edf = Edf([EdfSignal(np.arange(2), 1)])
-    with pytest.raises(ValueError, match="signals must not be empty"):
-        edf.signals = []
 
 
 def test_get_starttime_from_file_with_reserved_field_indicating_edfplus_but_no_annotations_signal(

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1094,7 +1094,7 @@ def test_append_signals_multiple():
 
 @pytest.mark.parametrize(
     ("length", "sampling_frequency"),
-    [(1001, 10), (999, 10), (1000, 1.0001), (1, 0.011)],
+    [(1001, 10), (999, 10), (1000, 10.001), (1, 0.011)],
 )
 def test_append_signals_raises_error_on_duration_mismatch(
     length: int,

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -487,20 +487,20 @@ def test_edf_signal_with_too_small_physical_range_fails():
 
 
 @pytest.mark.parametrize("data", [[-3, 3], [-3, 7], [-7, 7]])
-def test_edf_signal_data_can_be_set(data):
+def test_edf_signal_update_data(data):
     data = np.array(data)
     signal = EdfSignal(np.array([-5, 5]), 1)
-    signal.data = data
+    signal.update_data(data)
     np.testing.assert_array_equal(signal.data, data)
     np.testing.assert_array_equal(signal._digital, np.array([-32768, 32767]))
     assert signal.physical_range == FloatRange(data.min(), data.max())
 
 
 @pytest.mark.parametrize("length", [9, 11])
-def test_edf_signal_setting_data_fails_on_length_mismatch(length: int):
+def test_edf_signal_update_data_fails_on_length_mismatch(length: int):
     signal = EdfSignal(np.arange(10), 1)
     with pytest.raises(ValueError, match="Signal lengths must match"):
-        signal.data = np.arange(length)
+        signal.update_data(np.arange(length))
 
 
 def test_edf_signal_data_cannot_be_modified(dummy_edf_signal: EdfSignal):


### PR DESCRIPTION
Currently, the setter for `Edf.signals` allows to create non-compliant EDFs, e.g. by 
- not passing an annotations signal for an EDF+C
- passing a list of signals where the timekeeping signal is not the first annotations signal
- passing signals that have the correct overall duration, but are not compatible with the current data_record_duration

Removing the public setter and introducing more controlled methods for manipulation (`Edf.drop_signals` and `Edf.append_signals`) and a setter for `Edf.data` should allow to handle valid use cases more safely.