### PR TITLE
Add property `Edf.ordinary_signals`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Add `Edf.ordinary_signals`, which returns a tuple containing all non-annotation signals ([#16](https://github.com/the-siesta-group/edfio/pull/16))
+
 ### Fixed
 - Avoid floating point errors sometimes preventing the creation of an Edf with signals that are actually compatible in duration ([#15](https://github.com/the-siesta-group/edfio/pull/15)).
 

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1395,3 +1395,30 @@ def test_sampling_frequencies_leading_to_floating_point_issues_in_signal_duratio
     assert edf.num_data_records == 10
     assert edf.signals[0].samples_per_data_record == 22
     assert edf.signals[1].samples_per_data_record == 9
+
+
+def test_ordinary_signals():
+    edf = Edf(
+        [
+            EdfSignal(np.arange(10), 1, label="S1"),
+            _create_annotations_signal(
+                [EdfAnnotation(0, None, "ann 1")],
+                data_record_duration=1,
+                num_data_records=10,
+                with_timestamps=True,
+            ),
+            EdfSignal(np.arange(10), 1, label="S2"),
+            EdfSignal(np.arange(10), 1, label="S3"),
+            _create_annotations_signal(
+                [EdfAnnotation(0, None, "ann 2")],
+                data_record_duration=1,
+                num_data_records=10,
+                with_timestamps=False,
+            ),
+            EdfSignal(np.arange(10), 1, label="S4"),
+        ],
+        data_record_duration=1,
+    )
+    assert edf.labels == ("S1", "EDF Annotations", "S2", "S3", "EDF Annotations", "S4")
+    assert len(edf.ordinary_signals) == 4
+    assert [s.label for s in edf.ordinary_signals] == ["S1", "S2", "S3", "S4"]


### PR DESCRIPTION
This simplifies ignoring annotations signals while iterating over a recording's signals. The name of the property is based on the language used by the [EDF+ specs](https://www.edfplus.info/specs/edfplus.html).