### PR TITLE
Support missing subfields in EDF+ header fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 ## [0.4.0] - 2023-12-22
 
 ### Changed
+- Make EDF+ header fields `Patient` and `Recording` more tolerant regarding non-compliant inputs. when created from scratch, empty strings or `None` are now converted to `"X"`. When read from a file, omitted subfields are returned as `None` instead of throwing an exception ([#18](https://github.com/the-siesta-group/edfio/pull/18)).
+
+### Changed
 - Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()` ([#25](https://github.com/the-siesta-group/edfio/pull/25)).
 - Provide more concise `__repr__` for `Edf` and `EdfSignal` ([#26](https://github.com/the-siesta-group/edfio/pull/26)).
 - `Edf.append_signals()` now inserts new signals after the last ordinary (i.e. non-annotation) signal ([#29](https://github.com/the-siesta-group/edfio/pull/29)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+- Make EDF+ header fields `patient` and `recording` more tolerant regarding non-compliant inputs: omitted subfields are returned as `X` instead of throwing an exception ([#18](https://github.com/the-siesta-group/edfio/pull/18)).
+
 ### Fixed
 - Allow reading more non-standard starttime and startdate fields ([#30](https://github.com/the-siesta-group/edfio/pull/30)).
 
 ## [0.4.0] - 2023-12-22
-
-### Changed
-- Make EDF+ header fields `Patient` and `Recording` more tolerant regarding non-compliant inputs. when created from scratch, empty strings or `None` are now converted to `"X"`. When read from a file, omitted subfields are returned as `None` instead of throwing an exception ([#18](https://github.com/the-siesta-group/edfio/pull/18)).
 
 ### Changed
 - Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()` ([#25](https://github.com/the-siesta-group/edfio/pull/25)).

--- a/edfio/_utils.py
+++ b/edfio/_utils.py
@@ -94,11 +94,7 @@ def round_float_to_8_characters(
 
 def validate_subfields(subfields: dict[str, str]) -> None:
     for key, value in subfields.items():
+        if not value:
+            raise ValueError(f"Subfield {key} must not be an empty string")
         if " " in value:
             raise ValueError(f"Subfield {key} contains spaces: {value!r}")
-
-
-def _unknown_to_x(value: str | None) -> str:
-    if not value:
-        return "X"
-    return value

--- a/edfio/_utils.py
+++ b/edfio/_utils.py
@@ -94,7 +94,11 @@ def round_float_to_8_characters(
 
 def validate_subfields(subfields: dict[str, str]) -> None:
     for key, value in subfields.items():
-        if not value:
-            raise ValueError(f"Subfield {key} must not be an empty string")
         if " " in value:
             raise ValueError(f"Subfield {key} contains spaces: {value!r}")
+
+
+def _unknown_to_x(value: str | None) -> str:
+    if not value:
+        return "X"
+    return value

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -464,12 +464,12 @@ class Patient:
         return self._local_patient_identification
 
     @property
-    def code(self) -> str | None:
+    def code(self) -> str:
         """The code by which the patient is known in the hospital administration."""
         return self._get_subfield(0)
 
     @property
-    def sex(self) -> str | None:
+    def sex(self) -> str:
         """Sex, `F` for female, `M` for male, `X` if anonymized."""
         return self._get_subfield(1)
 
@@ -482,19 +482,19 @@ class Patient:
         return decode_edfplus_date(birthdate_field)
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """The patient's name."""
         return self._get_subfield(3)
 
     @property
-    def additional(self) -> tuple[str | None, ...]:
+    def additional(self) -> tuple[str, ...]:
         """Optional additional subfields."""
         return tuple(self._local_patient_identification.split()[4:])
 
-    def _get_subfield(self, idx: int) -> str | None:
+    def _get_subfield(self, idx: int) -> str:
         subfields = self._local_patient_identification.split()
         if len(subfields) <= idx:
-            return None
+            return "X"
         return subfields[idx]
 
 
@@ -579,29 +579,29 @@ class Recording:
         return decode_edfplus_date(startdate_field)
 
     @property
-    def hospital_administration_code(self) -> str | None:
+    def hospital_administration_code(self) -> str:
         """The hospital administration code of the investigation."""
         return self._get_subfield(2)
 
     @property
-    def investigator_technician_code(self) -> str | None:
+    def investigator_technician_code(self) -> str:
         """A code specifying the responsible investigator or technician."""
         return self._get_subfield(3)
 
     @property
-    def equipment_code(self) -> str | None:
+    def equipment_code(self) -> str:
         """A code specifying the used equipment."""
         return self._get_subfield(4)
 
     @property
-    def additional(self) -> tuple[str | None, ...]:
+    def additional(self) -> tuple[str, ...]:
         """Optional additional subfields."""
         return tuple(self._local_recording_identification.split()[5:])
 
-    def _get_subfield(self, idx: int) -> str | None:
+    def _get_subfield(self, idx: int) -> str:
         subfields = self._local_recording_identification.split()
         if len(subfields) <= idx:
-            return None
+            return "X"
         return subfields[idx]
 
 

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -396,19 +396,20 @@ class Patient:
 
     Parsing from/to the string containing the local_patient_identification header field
     is done according to the EDF+ specs. Subfields must be ASCII (32..126) and may not
-    contain spaces.
+    contain spaces. None values or empty strings are interpreted as unknown value and
+    encoded as `"X"`.
 
     Parameters
     ----------
-    code : str, default: `"X"`
+    code : str | None, default: `"X"`
         The code by which the patient is known in the hospital administration.
-    sex : `{"X", "F", "M"}`, default: `"X"`
+    sex : `{"X", "F", "M"}` | None, default: `"X"`
         Sex, `F` for female, `M` for male, `X` if anonymized.
     birthdate : datetime.date | None, default: None
         Patient birthdate, stored as `X` if `None`.
-    name : str, default: `"X"`
+    name : str | None, default: `"X"`
         The patient's name, stored as `X` if `None`.
-    additional : Sequence[str], default: `()`
+    additional : Sequence[str | None] | None, default: `()`
         Optional additional subfields. Will be stored in the header field separated by
         spaces.
     """
@@ -503,20 +504,21 @@ class Recording:
 
     Parsing from/to the string containing the local_recording_identification header
     field is done according to the EDF+ specs. Subfields must be ASCII (32..126) and may
-    not contain spaces.
+    not contain spaces. None values or empty strings are interpreted as unknown value and
+    encoded as `"X"`.
 
     Parameters
     ----------
     startdate : datetime.date | None, default: None
         The recording startdate.
-    hospital_administration_code : str, default: `"X"`
+    hospital_administration_code : str | None, default: `"X"`
         The hospital administration code of the investigation, e.g., EEG number or PSG
         number.
-    investigator_technician_code : str, default: `"X"`
+    investigator_technician_code : str | None, default: `"X"`
         A code specifying the responsible investigator or technician.
-    equipment_code : str, default: `"X"`
+    equipment_code : str | None, default: `"X"`
         A code specifying the used equipment.
-    additional : Sequence[str], default: `()`
+    additional : Sequence[str | None] | None, default: `()`
         Optional additional subfields. Will be stored in the header field separated by
         spaces.
     """

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -458,32 +458,46 @@ class Patient:
     @property
     def code(self) -> str:
         """The code by which the patient is known in the hospital administration."""
-        return self._get_subfield(0)
+        return self.get_subfield(0)
 
     @property
     def sex(self) -> str:
         """Sex, `F` for female, `M` for male, `X` if anonymized."""
-        return self._get_subfield(1)
+        return self.get_subfield(1)
 
     @property
     def birthdate(self) -> datetime.date:
         """Patient birthdate."""
-        birthdate_field = self._get_subfield(2)
-        if birthdate_field == "X" or birthdate_field is None:
+        birthdate_field = self.get_subfield(2)
+        if birthdate_field == "X":
             raise AnonymizedDateError("Patient birthdate is not available ('X').")
         return decode_edfplus_date(birthdate_field)
 
     @property
     def name(self) -> str:
         """The patient's name."""
-        return self._get_subfield(3)
+        return self.get_subfield(3)
 
     @property
     def additional(self) -> tuple[str, ...]:
         """Optional additional subfields."""
         return tuple(self._local_patient_identification.split()[4:])
 
-    def _get_subfield(self, idx: int) -> str:
+    def get_subfield(self, idx: int) -> str:
+        """
+        Access a subfield of the local patient identification field by index.
+
+        Parameters
+        ----------
+        idx : int
+            The index of the subfield to access.
+
+        Returns
+        -------
+        str
+            The subfield at the specified index. If the index exceeds the actually
+            available number of subfields, the return value is `"X"`.
+        """
         subfields = self._local_patient_identification.split()
         if len(subfields) <= idx:
             return "X"
@@ -558,12 +572,12 @@ class Recording:
     @property
     def startdate(self) -> datetime.date:
         """The recording startdate."""
-        if not self._local_recording_identification.startswith("Startdate"):
+        if not self._local_recording_identification.startswith("Startdate "):
             raise ValueError(
                 f"Local recording identification field {self._local_recording_identification!r} does not follow EDF+ standard."
             )
         startdate_field = self.get_subfield(1)
-        if startdate_field == "X" or startdate_field is None:
+        if startdate_field == "X":
             raise AnonymizedDateError("Recording startdate is not available ('X').")
         return decode_edfplus_date(startdate_field)
 
@@ -601,7 +615,7 @@ class Recording:
         -------
         str
             The subfield at the specified index. If the index exceeds the actually
-            specified number of subfields, the return value is `"X"`.
+            available number of subfields, the return value is `"X"`.
         """
         subfields = self._local_recording_identification.split()
         if len(subfields) <= idx:

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -573,7 +573,7 @@ class Recording:
             raise ValueError(
                 f"Local recording identification field {self._local_recording_identification!r} does not follow EDF+ standard."
             )
-        startdate_field = self._get_subfield(1)
+        startdate_field = self.get_subfield(1)
         if startdate_field == "X" or startdate_field is None:
             raise AnonymizedDateError("Recording startdate is not available ('X').")
         return decode_edfplus_date(startdate_field)
@@ -581,24 +581,39 @@ class Recording:
     @property
     def hospital_administration_code(self) -> str:
         """The hospital administration code of the investigation."""
-        return self._get_subfield(2)
+        return self.get_subfield(2)
 
     @property
     def investigator_technician_code(self) -> str:
         """A code specifying the responsible investigator or technician."""
-        return self._get_subfield(3)
+        return self.get_subfield(3)
 
     @property
     def equipment_code(self) -> str:
         """A code specifying the used equipment."""
-        return self._get_subfield(4)
+        return self.get_subfield(4)
 
     @property
     def additional(self) -> tuple[str, ...]:
         """Optional additional subfields."""
         return tuple(self._local_recording_identification.split()[5:])
 
-    def _get_subfield(self, idx: int) -> str:
+    def get_subfield(self, idx: int) -> str:
+        """
+        Access a subfield of the local recording identification field by index.
+
+        Parameters
+        ----------
+        idx : int
+            The index of the subfield to access. The first subfield (starting at
+            index 0) should always be "Startdate" according to the EDF+ spedification.
+
+        Returns
+        -------
+        str
+            The subfield at the specified index. If the index exceeds the actually
+            specified number of subfields, the return value is `"X"`.
+        """
         subfields = self._local_recording_identification.split()
         if len(subfields) <= idx:
             return "X"

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -31,7 +31,6 @@ from edfio._header_field import (
 from edfio._utils import (
     FloatRange,
     IntRange,
-    _unknown_to_x,
     calculate_gain_and_offset,
     decode_edfplus_date,
     encode_annotation_duration,
@@ -396,20 +395,19 @@ class Patient:
 
     Parsing from/to the string containing the local_patient_identification header field
     is done according to the EDF+ specs. Subfields must be ASCII (32..126) and may not
-    contain spaces. None values or empty strings are interpreted as unknown value and
-    encoded as `"X"`.
+    contain spaces.
 
     Parameters
     ----------
-    code : str | None, default: `"X"`
+    code : str, default: `"X"`
         The code by which the patient is known in the hospital administration.
-    sex : `{"X", "F", "M"}` | None, default: `"X"`
+    sex : `{"X", "F", "M"}`, default: `"X"`
         Sex, `F` for female, `M` for male, `X` if anonymized.
     birthdate : datetime.date | None, default: None
         Patient birthdate, stored as `X` if `None`.
-    name : str | None, default: `"X"`
+    name : str, default: `"X"`
         The patient's name, stored as `X` if `None`.
-    additional : Sequence[str | None] | None, default: `()`
+    additional : Sequence[str], default: `()`
         Optional additional subfields. Will be stored in the header field separated by
         spaces.
     """
@@ -417,30 +415,24 @@ class Patient:
     def __init__(
         self,
         *,
-        code: str | None = "X",
-        sex: Literal["F", "M", "X"] | None = "X",
+        code: str = "X",
+        sex: Literal["F", "M", "X"] = "X",
         birthdate: datetime.date | None = None,
-        name: str | None = "X",
-        additional: Sequence[str | None] | None = (),
+        name: str = "X",
+        additional: Sequence[str] = (),
     ) -> None:
-        code = _unknown_to_x(code)
-        name = _unknown_to_x(name)
-        if not sex:
-            sex = "X"
-        elif sex not in ("F", "M", "X"):
+        if sex not in ("F", "M", "X"):
             raise ValueError(f"Invalid sex: {sex}, must be one of F, M, X")
         if birthdate is None:
             birthdate_field = "X"
         else:
             birthdate_field = encode_edfplus_date(birthdate)
-        if additional is None:
-            additional = ()
         subfields = {
             "code": code,
             "sex": sex,
             "birthdate": birthdate_field,
             "name": name,
-            **{f"additional[{i}]": _unknown_to_x(v) for i, v in enumerate(additional)},
+            **{f"additional[{i}]": v for i, v in enumerate(additional)},
         }
         validate_subfields(subfields)
         local_patient_identification = " ".join(subfields.values())
@@ -504,21 +496,20 @@ class Recording:
 
     Parsing from/to the string containing the local_recording_identification header
     field is done according to the EDF+ specs. Subfields must be ASCII (32..126) and may
-    not contain spaces. None values or empty strings are interpreted as unknown value and
-    encoded as `"X"`.
+    not contain spaces.
 
     Parameters
     ----------
     startdate : datetime.date | None, default: None
         The recording startdate.
-    hospital_administration_code : str | None, default: `"X"`
+    hospital_administration_code : str, default: `"X"`
         The hospital administration code of the investigation, e.g., EEG number or PSG
         number.
-    investigator_technician_code : str | None, default: `"X"`
+    investigator_technician_code : str, default: `"X"`
         A code specifying the responsible investigator or technician.
-    equipment_code : str | None, default: `"X"`
+    equipment_code : str, default: `"X"`
         A code specifying the used equipment.
-    additional : Sequence[str | None] | None, default: `()`
+    additional : Sequence[str], default: `()`
         Optional additional subfields. Will be stored in the header field separated by
         spaces.
     """
@@ -527,23 +518,21 @@ class Recording:
         self,
         *,
         startdate: datetime.date | None = None,
-        hospital_administration_code: str | None = "X",
-        investigator_technician_code: str | None = "X",
-        equipment_code: str | None = "X",
-        additional: Sequence[str | None] | None = (),
+        hospital_administration_code: str = "X",
+        investigator_technician_code: str = "X",
+        equipment_code: str = "X",
+        additional: Sequence[str] = (),
     ) -> None:
         if startdate is None:
             startdate_field = "X"
         else:
             startdate_field = encode_edfplus_date(startdate)
-        if additional is None:
-            additional = ()
         subfields = {
             "startdate": startdate_field,
-            "hospital_administration_code": _unknown_to_x(hospital_administration_code),
-            "investigator_technician_code": _unknown_to_x(investigator_technician_code),
-            "equipment_code": _unknown_to_x(equipment_code),
-            **{f"additional[{i}]": _unknown_to_x(v) for i, v in enumerate(additional)},
+            "hospital_administration_code": hospital_administration_code,
+            "investigator_technician_code": investigator_technician_code,
+            "equipment_code": equipment_code,
+            **{f"additional[{i}]": v for i, v in enumerate(additional)},
         }
         validate_subfields(subfields)
         local_recording_identification = " ".join(("Startdate", *subfields.values()))

--- a/tests/test_edfplus_header.py
+++ b/tests/test_edfplus_header.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 
 import numpy as np

--- a/tests/test_edfplus_header.py
+++ b/tests/test_edfplus_header.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 
 import numpy as np
@@ -403,7 +401,7 @@ def test_recording_raises_error_on_empty_subfields(
 
 
 def test_read_recording_all_subfields_missing():
-    recording = Recording._from_str("Startdate")
+    recording = Recording._from_str("Startdate ")
     assert recording.hospital_administration_code == "X"
     assert recording.investigator_technician_code == "X"
     assert recording.equipment_code == "X"

--- a/tests/test_edfplus_header.py
+++ b/tests/test_edfplus_header.py
@@ -338,31 +338,20 @@ def test_edf_startdate_falls_back_to_legacy_field_if_recording_field_is_not_vali
 
 
 @pytest.mark.parametrize(
-    ("code", "sex", "name", "additional"),
+    ("code", "name", "additional"),
     [
-        ("", "X", "X", ()),
-        ("X", "", "", ()),
-        ("X", "X", "X", ("add1", "", "add2")),
-        (None, "X", "X", None),
-        ("X", None, None, None),
-        ("X", "X", "X", (None, "add2")),
+        ("", "X", ()),
+        ("X", "", ()),
+        ("X", "X", ("add1", "", "add2")),
     ],
 )
-def test_patient_assumes_unspecified_subfields_as_unknown(
-    code: str | None,
-    sex: str | None,
-    name: str | None,
-    additional: tuple[str | None, ...] | None,
+def test_patient_raises_error_on_empty_subfields(
+    code: str,
+    name: str,
+    additional: tuple[str, ...],
 ):
-    patient = Patient(code=code, sex=sex, name=name, additional=additional)
-    assert patient.code == code if code else "X"
-    assert patient.sex == sex if sex else "X"
-    assert patient.name == name if name else "X"
-    expected_additional = list(additional) if additional else []
-    for i in range(len(expected_additional)):
-        if expected_additional[i] is None or expected_additional[i] == "":
-            expected_additional[i] = "X"
-    assert patient.additional == tuple(expected_additional)
+    with pytest.raises(ValueError, match="must not be an empty string"):
+        Patient(code=code, name=name, additional=additional)
 
 
 def test_read_patient_all_subfields_missing():
@@ -392,55 +381,25 @@ def test_read_patient_some_subfields_missing():
         "additional",
     ),
     [
-        ("X", "X", "X", ()),
-        ("X", "X", "", ()),
-        ("X", "", "X", ()),
         ("", "X", "X", ()),
-        ("X", "", "", ()),
-        ("", "X", "", ()),
-        ("", "", "X", ()),
-        ("", "", "", ()),
-        ("X", "X", None, None),
-        ("X", None, "X", None),
-        (None, "X", "X", None),
-        ("X", None, None, None),
-        (None, "X", None, None),
-        (None, None, "X", None),
-        (None, None, None, None),
-        ("X", "X", "X", ("add1", "add2")),
-        ("X", "X", "X", ("add1", "")),
-        ("X", "X", "X", (None, "add2")),
+        ("X", "", "X", ()),
+        ("X", "X", "", ()),
+        ("X", "X", "X", ("add1", "", "add2")),
     ],
 )
-def test_recording_assumes_unspecified_subfields_as_unknown(
-    hospital_administration_code: str | None,
-    investigator_technician_code: str | None,
-    equipment_code: str | None,
-    additional: tuple[str | None, ...] | None,
+def test_recording_raises_error_on_empty_subfields(
+    hospital_administration_code: str,
+    investigator_technician_code: str,
+    equipment_code: str,
+    additional: tuple[str, ...],
 ):
-    recording = Recording(
-        startdate=datetime.date(2002, 3, 2),
-        hospital_administration_code=hospital_administration_code,
-        investigator_technician_code=investigator_technician_code,
-        equipment_code=equipment_code,
-        additional=additional,
-    )
-    assert (
-        recording.hospital_administration_code == hospital_administration_code
-        if hospital_administration_code
-        else "X"
-    )
-    assert (
-        recording.investigator_technician_code == investigator_technician_code
-        if investigator_technician_code
-        else "X"
-    )
-    assert recording.equipment_code == equipment_code if equipment_code else "X"
-    expected_additional = list(additional) if additional else []
-    for i in range(len(expected_additional)):
-        if expected_additional[i] is None or expected_additional[i] == "":
-            expected_additional[i] = "X"
-    assert recording.additional == tuple(expected_additional)
+    with pytest.raises(ValueError, match="must not be an empty string"):
+        Recording(
+            hospital_administration_code=hospital_administration_code,
+            investigator_technician_code=investigator_technician_code,
+            equipment_code=equipment_code,
+            additional=additional,
+        )
 
 
 def test_read_recording_all_subfields_missing():

--- a/tests/test_edfplus_header.py
+++ b/tests/test_edfplus_header.py
@@ -367,9 +367,9 @@ def test_patient_assumes_unspecified_subfields_as_unknown(
 
 def test_read_patient_all_subfields_missing():
     patient = Patient._from_str("")
-    assert patient.code is None
-    assert patient.sex is None
-    assert patient.name is None
+    assert patient.code == "X"
+    assert patient.sex == "X"
+    assert patient.name == "X"
     assert patient.additional == ()
     with pytest.raises(AnonymizedDateError, match="birthdate is not available"):
         patient.birthdate
@@ -379,7 +379,7 @@ def test_read_patient_some_subfields_missing():
     patient = Patient._from_str("X M 21-AUG-1984")
     assert patient.code == "X"
     assert patient.sex == "M"
-    assert patient.name is None
+    assert patient.name == "X"
     assert patient.birthdate == datetime.date(1984, 8, 21)
     assert patient.additional == ()
 
@@ -445,9 +445,9 @@ def test_recording_assumes_unspecified_subfields_as_unknown(
 
 def test_read_recording_all_subfields_missing():
     recording = Recording._from_str("Startdate")
-    assert recording.hospital_administration_code is None
-    assert recording.investigator_technician_code is None
-    assert recording.equipment_code is None
+    assert recording.hospital_administration_code == "X"
+    assert recording.investigator_technician_code == "X"
+    assert recording.equipment_code == "X"
     assert recording.additional == ()
     with pytest.raises(AnonymizedDateError, match="startdate is not available"):
         recording.startdate
@@ -456,7 +456,7 @@ def test_read_recording_all_subfields_missing():
 def test_read_recording_some_subfields_missing():
     recording = Recording._from_str("Startdate 13-MAY-2025 X")
     assert recording.hospital_administration_code == "X"
-    assert recording.investigator_technician_code is None
-    assert recording.equipment_code is None
+    assert recording.investigator_technician_code == "X"
+    assert recording.equipment_code == "X"
     assert recording.additional == ()
     assert recording.startdate == datetime.date(2025, 5, 13)


### PR DESCRIPTION
Increase tolerance regarding EDF+ files not compliant with the EDF+ standard. At the same time, make the API more comfortable to use by accepting `None` or empty strings as unspecified subfields.