### PR TITLE
Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()` ([#25](https://github.com/the-siesta-group/edfio/pull/25)).
+
 ### Fixed
 - Avoid floating point errors sometimes preventing the creation of an Edf with signals that are actually compatible in duration ([#15](https://github.com/the-siesta-group/edfio/pull/15)).
 - Allow reading EDF+ startdate and birthdate with non-uppercase month ([#19](https://github.com/the-siesta-group/edfio/pull/19)).

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -289,7 +289,7 @@ def test_edf_init_all_parameters():
     assert edf._bytes_in_header_record == b"512".ljust(8)
     assert edf._reserved == b"".ljust(44)
     assert edf.__data_record_duration == b"2.5".ljust(8)
-    assert edf._num_signals == b"1".ljust(4)
+    assert edf.__num_signals == b"1".ljust(4)
 
 
 def test_edf_init_signals_with_different_durations():
@@ -1066,7 +1066,8 @@ def test_edf_with_only_annotations_can_be_written(tmp_file: Path):
     assert edf.bytes_in_header_record == 512
     assert edf.reserved == "EDF+C"
     assert edf.data_record_duration == 0
-    assert edf.num_signals == 1
+    assert edf.num_signals == 0
+    assert edf._num_signals == 1
     assert edf.num_data_records == 1
     assert edf.annotations == annotations
 

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -477,7 +477,7 @@ def test_edf_get_signal_ambiguous_label():
 )
 def test_edf_field_cannot_be_set_publicly(field_name: str):
     edf = read_edf(EDF_FILE)
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError, match="can't set attribute|has no setter"):
         setattr(edf, field_name, None)
 
 

--- a/tests/test_edfplus_annotations.py
+++ b/tests/test_edfplus_annotations.py
@@ -132,7 +132,8 @@ def test_write_edf_with_annotations(tmp_file: Path):
     edf = read_edf(tmp_file)
     assert edf.annotations == annotations
     assert edf.reserved == "EDF+C"
-    assert edf.num_signals == 2
+    assert edf.num_signals == 1
+    assert edf._num_signals == 2
 
 
 def test_annotations_outside_recording_limits(tmp_file: Path):


### PR DESCRIPTION
See #16 for a detailed discussion.