### PR TITLE
Let `Edf.append_signals` insert after the last ordinary signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()` ([#25](https://github.com/the-siesta-group/edfio/pull/25)).
 - Provide more concise `__repr__` for `Edf` and `EdfSignal` ([#26](https://github.com/the-siesta-group/edfio/pull/26)).
-- `Edf.append_signals()` now inserts new signals after the last ordinary (i.e. non-annotation) signal ([#28](https://github.com/the-siesta-group/edfio/pull/28)).
+- `Edf.append_signals()` now inserts new signals after the last ordinary (i.e. non-annotation) signal ([#29](https://github.com/the-siesta-group/edfio/pull/29)).
 
 ### Fixed
 - Avoid floating point errors sometimes preventing the creation of an Edf with signals that are actually compatible in duration ([#15](https://github.com/the-siesta-group/edfio/pull/15)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Exclude EDF+ annotation signals from `Edf.signals`, `Edf.num_signals`, and `Edf.drop_signals()` ([#25](https://github.com/the-siesta-group/edfio/pull/25)).
 - Provide more concise `__repr__` for `Edf` and `EdfSignal` ([#26](https://github.com/the-siesta-group/edfio/pull/26)).
+- `Edf.append_signals()` now inserts new signals after the last ordinary (i.e. non-annotation) signal ([#28](https://github.com/the-siesta-group/edfio/pull/28)).
 
 ### Fixed
 - Avoid floating point errors sometimes preventing the creation of an Edf with signals that are actually compatible in duration ([#15](https://github.com/the-siesta-group/edfio/pull/15)).

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -1181,10 +1181,12 @@ class Edf:
 
     def append_signals(self, new_signals: EdfSignal | Iterable[EdfSignal]) -> None:
         """
-        Append one or more signal(s) to the Edf recording, after all existing ones.
+        Append one or more signal(s) to the Edf recording.
 
         Every signal must be compatible with the current `data_record_duration` and all
-        signal durations must match the overall recording duration.
+        signal durations must match the overall recording duration. For recordings
+        containing EDF+ annotation signals, the new signals are inserted after the last
+        ordinary (i.e. non-annotation) signal.
 
         Parameters
         ----------
@@ -1193,7 +1195,17 @@ class Edf:
         """
         if isinstance(new_signals, EdfSignal):
             new_signals = [new_signals]
-        self._set_signals((*self._signals, *new_signals))
+        last_ordinary_index = 0
+        for i, signal in enumerate(self._signals):
+            if signal.label != "EDF Annotations":
+                last_ordinary_index = i
+        self._set_signals(
+            [
+                *self._signals[: last_ordinary_index + 1],
+                *new_signals,
+                *self._signals[last_ordinary_index + 1 :],
+            ]
+        )
 
     @property
     def _annotation_signals(self) -> Iterable[EdfSignal]:

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1171,6 +1171,30 @@ def test_append_signals_multiple():
         assert actual == expected
 
 
+def test_append_signals_appends_after_last_ordinary_signal():
+    edf = Edf(
+        [
+            EdfSignal(np.arange(3), 1, label="S1"),
+            EdfSignal(np.arange(3), 1, label="S2"),
+            _create_annotations_signal(
+                (), data_record_duration=1, num_data_records=3, with_timestamps=True
+            ),
+            EdfSignal(np.arange(3), 1, label="S3"),
+            _create_annotations_signal(
+                (), data_record_duration=1, num_data_records=3, with_timestamps=True
+            ),
+        ]
+    )
+    edf.append_signals(
+        [
+            EdfSignal(np.arange(3), 1, label="S4"),
+            EdfSignal(np.arange(3), 1, label="S5"),
+        ]
+    )
+    expected = ["S1", "S2", "EDF Annotations", "S3", "S4", "S5", "EDF Annotations"]
+    assert [s.label for s in edf._signals] == expected
+
+
 @pytest.mark.parametrize(
     ("length", "sampling_frequency"),
     [(1001, 10), (999, 10), (1000, 10.001), (1, 0.011)],


### PR DESCRIPTION
This helps to keep the EDF+ annotations signal at the last position.