### PR TITLE
Run test job with oldest and latest supported NumPy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,16 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        numpy: ["--pre numpy"]
+        include:
+          - python-version: "3.9"
+            numpy: numpy==1.22.0
+          - python-version: "3.10"
+            numpy: numpy==1.22.0
+          - python-version: "3.11"
+            numpy: numpy==1.23.2
+          - python-version: "3.12"
+            numpy: numpy==1.26.0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -42,7 +52,8 @@ jobs:
         run: |
           pip install -U pip
           pip install poetry==1.7.0
-          poetry install
+          poetry install --only dev
+          poetry run pip install ${{matrix.numpy}}
       - name: Pre-commit
         run: |
           poetry run pre-commit run --all-files


### PR DESCRIPTION
Currently, the CI test job installs the latest standard release of NumPy. To ensure compatibility with all versions supported based on the entry `>=1.22.0` in `pyproject.toml`,  I think it would be good to run tests on
- the oldest supported version for each Python version
- the latest pre-release (since NumPy 2.0 will be out soon)
