### PR TITLE
BUG: Fix bug with version

### DIFF
--- a/edfio/__init__.py
+++ b/edfio/__init__.py
@@ -7,7 +7,7 @@ try:
     from importlib.metadata import version
 
     __version__ = version("edfio")
-except Exception:
+except Exception:  # pragma: no cover
     __version__ = "0.0.0"
 
 

--- a/edfio/__init__.py
+++ b/edfio/__init__.py
@@ -3,7 +3,12 @@ from edfio.edf_annotations import EdfAnnotation
 from edfio.edf_header import AnonymizedDateError, Patient, Recording
 from edfio.edf_signal import EdfSignal
 
-__version__ = "0.0.0"
+try:
+    from importlib.metadata import version
+
+    __version__ = version("edfio")
+except Exception:
+    __version__ = "0.0.0"
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,4 +81,4 @@ pretty = true
 packages = ["edfio"]
 
 [tool.coverage.report]
-exclude_lines = ["@abstractmethod", "@overload"]
+exclude_also = ["@abstractmethod", "@overload"]


### PR DESCRIPTION
On latest `main` I just did:
```
$ git clone git@github.com:/the-siesta-group/edfio.git
$ cd edfio
$ pip install -ve .
...
Successfully built edfio
Installing collected packages: edfio
Successfully installed edfio-0.4.0.post28+b17cad2
$ cd ~
$ python -c "import edfio; print(edfio)"
<module 'edfio' from '/home/larsoner/python/edfio/edfio/__init__.py'>
$ python -c "import edfio; print(edfio.__version__)"
0.0.0
```
So I don't think this is yet working as intended even with #44. After the changes in this PR (which follow what MNE-Python does to get the version) I get:
```
$ python -c "import edfio; print(edfio.__version__)"
0.4.0.post28+b17cad2
```