### PR TITLE
Testing which condition produced the ZeroDivisionError, closes #50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased]
-When reading signal data that throws `ZeroDivisionError`, which condition caused the error is now tested for (either `digital_min == digital_max` or `physical_max == physical_min`) ([#51](https://github.com/the-siesta-group/edfio/pull/51)).
+- When reading signal data that throws `ZeroDivisionError`, which condition caused the error is now tested for (either `digital_min == digital_max` or `physical_max == physical_min`) ([#51](https://github.com/the-siesta-group/edfio/pull/51)).
 
 ## [0.4.2] - 2024-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+When reading signal data that throws `ZeroDivisionError`, which condition caused the error is now tested for (either `digital_min == digital_max` or `physical_max == physical_min`) ([#51](https://github.com/the-siesta-group/edfio/pull/51)).
 
 ## [0.4.2] - 2024-05-13
 

--- a/edfio/edf_signal.py
+++ b/edfio/edf_signal.py
@@ -331,9 +331,14 @@ class EdfSignal:
             )
         except ZeroDivisionError:
             data = self.digital.astype(np.float64)
-            warnings.warn(
-                f"Digital minimum equals digital maximum ({self.digital_min}) for {self.label}, returning uncalibrated signal."
-            )
+            if self.digital_max == self.digital_min:
+                warnings.warn(
+                    f"Digital minimum equals digital maximum ({self.digital_min}) for {self.label}, returning uncalibrated signal."
+                )
+            else:
+                warnings.warn(
+                    f"Physical minimum equals physical maximum ({self.physical_min}) for {self.label}, returning uncalibrated signal."
+                )
         except ValueError:
             data = self.digital.astype(np.float64)
         else:

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -107,6 +107,13 @@ def test_q8_edf_signal_where_digital_min_equals_digital_max_data_emits_warning_a
     with pytest.warns(UserWarning, match="Digital minimum equals .* uncalibrated .*"):
         np.testing.assert_equal(signal.data, np.array([-32768, 32767]))
 
+def test_q8_edf_signal_where_physical_min_equals_physical_max_data_emits_warning_and_returns_uncalibrated():
+    signal = EdfSignal(np.array([-10, 10]), 1, physical_range=(-10, 10))
+    signal._physical_min = b"0       "
+    signal._physical_max = b"0       "
+    with pytest.warns(UserWarning, match="Physical minimum equals .* uncalibrated .*"):
+        np.testing.assert_equal(signal.data, np.array([-32768, 32767]))
+
 
 @pytest.mark.parametrize(
     ("sampling_frequency", "num_samples", "expected_data_record_duration"),

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -107,6 +107,7 @@ def test_q8_edf_signal_where_digital_min_equals_digital_max_data_emits_warning_a
     with pytest.warns(UserWarning, match="Digital minimum equals .* uncalibrated .*"):
         np.testing.assert_equal(signal.data, np.array([-32768, 32767]))
 
+
 def test_q8_edf_signal_where_physical_min_equals_physical_max_data_emits_warning_and_returns_uncalibrated():
     signal = EdfSignal(np.array([-10, 10]), 1, physical_range=(-10, 10))
     signal._physical_min = b"0       "


### PR DESCRIPTION
Testing which condition produced the ZeroDivisionError when reading signal data.

Closes #50 