### PR TITLE
Support partial reading of EDF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Load a segment of EDF raw data from a signal without reading the entire file using `EdfSignal.get_slice` method ([#58](https://github.com/the-siesta-group/edfio/pull/58)).
+
 ## [0.4.4] - 2024-09-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased]
 
 ### Added
-- Load a segment of EDF raw data from a signal without reading the entire file using `EdfSignal.get_slice` method ([#58](https://github.com/the-siesta-group/edfio/pull/58)).
+- Load a segment of EDF raw data from a signal without reading the entire file using `EdfSignal.get_data_slice` method ([#58](https://github.com/the-siesta-group/edfio/pull/58)).
+- Load annotations from a specific time window of the EDF file without reading the entire file using `Edf.get_annotations` method ([#58](https://github.com/the-siesta-group/edfio/pull/58)).
 
 ## [0.4.4] - 2024-09-25
 

--- a/edfio/_lazy_loading.py
+++ b/edfio/_lazy_loading.py
@@ -4,6 +4,13 @@ import numpy as np
 from numpy.typing import NDArray
 
 
+class InvalidRangeOfDataRecordsError(ValueError):
+    def __init__(self, start_record: int, end_record: int, num_records: int):
+        super().__init__(
+            f"Invalid specification of records to load: {start_record}, {end_record}. File contains {num_records} records."
+        )
+
+
 class LazyLoader:
     """
     Class to load data for a single signal from a buffer of EDF data records (array or memmap).
@@ -55,8 +62,8 @@ class LazyLoader:
             or start_record < 0
             or end_record > self.buffer.shape[0]
         ):
-            raise ValueError(
-                f"Invalid specification of records to load: {start_record}, {end_record}."
+            raise InvalidRangeOfDataRecordsError(
+                start_record, end_record, self.buffer.shape[0]
             )
         return self.buffer[
             start_record:end_record, self.start_sample : self.end_sample

--- a/edfio/_lazy_loading.py
+++ b/edfio/_lazy_loading.py
@@ -4,13 +4,6 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-class InvalidRangeOfDataRecordsError(ValueError):
-    def __init__(self, start_record: int, end_record: int, num_records: int):
-        super().__init__(
-            f"Invalid specification of records to load: {start_record}, {end_record}. File contains {num_records} records."
-        )
-
-
 class LazyLoader:
     """
     Class to load data for a single signal from a buffer of EDF data records (array or memmap).
@@ -62,9 +55,7 @@ class LazyLoader:
             or start_record < 0
             or end_record > self.buffer.shape[0]
         ):
-            raise InvalidRangeOfDataRecordsError(
-                start_record, end_record, self.buffer.shape[0]
-            )
+            raise ValueError("Invalid slice: Slice exceeds EDF duration")
         return self.buffer[
             start_record:end_record, self.start_sample : self.end_sample
         ].flatten()

--- a/edfio/_lazy_loading.py
+++ b/edfio/_lazy_loading.py
@@ -1,0 +1,63 @@
+from typing import Any, Optional, Union
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+class LazyLoader:
+    """
+    Class to load data for a single signal from a buffer of EDF data records (array or memmap).
+
+    Parameters
+    ----------
+    buffer : numpy.ndarray or numpy.memmap
+        Buffer of EDF data records.
+    start_sample : int
+        Offset of the signal in the data records (in samples).
+    end_sample : int
+        End of the signal in the data records (in samples).
+    """
+
+    def __init__(
+        self,
+        buffer: Union[NDArray[np.int16], np.memmap[Any, np.dtype[np.int16]]],
+        start_sample: int,
+        end_sample: int,
+    ) -> None:
+        self.buffer = buffer
+        self.start_sample = start_sample
+        self.end_sample = end_sample
+
+    def load(
+        self, start_record: Optional[int] = None, end_record: Optional[int] = None
+    ) -> NDArray[np.int16]:
+        """
+        Load signal data from the buffer.
+
+        Parameters
+        ----------
+        start_record : int, optional
+            The first EDF data record to load samples from. If None, load from the beginning of the buffer.
+        end_record : int, optional
+            The last EDF data record to load samples from. If None, load until the end of the buffer.
+
+        Returns
+        -------
+        numpy.ndarray
+            Signal data (digital).
+        """
+        if start_record is None:
+            start_record = 0
+        if end_record is None:
+            end_record = self.buffer.shape[0]
+        if (
+            end_record < start_record
+            or start_record < 0
+            or end_record > self.buffer.shape[0]
+        ):
+            raise ValueError(
+                f"Invalid specification of records to load: {start_record}, {end_record}."
+            )
+        return self.buffer[
+            start_record:end_record, self.start_sample : self.end_sample
+        ].flatten()

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from typing import Any, Literal
 
 import numpy as np
-import numpy.typing as npt
 
 from edfio._header_field import (
     decode_date,
@@ -29,6 +28,7 @@ from edfio._header_field import (
     encode_str,
     encode_time,
 )
+from edfio._lazy_loading import LazyLoader
 from edfio.edf_annotations import (
     EdfAnnotation,
     _create_annotations_signal,
@@ -248,11 +248,7 @@ class Edf:
 
         for signal, start, end in zip(self._signals, starts, ends):
             if lazy_load_data:
-
-                def lazy_load(s: int = start, e: int = end) -> npt.NDArray[np.int16]:
-                    return datarecords[:, s:e].flatten()
-
-                signal._lazy_loader = lazy_load
+                signal._lazy_loader = LazyLoader(datarecords, start, end)
             else:
                 signal._digital = datarecords[:, start:end].flatten()
 

--- a/edfio/edf_signal.py
+++ b/edfio/edf_signal.py
@@ -14,7 +14,7 @@ from edfio._header_field import (
     encode_int,
     encode_str,
 )
-from edfio._lazy_loading import InvalidRangeOfDataRecordsError, LazyLoader
+from edfio._lazy_loading import LazyLoader
 
 
 class _IntRange(NamedTuple):
@@ -380,12 +380,7 @@ class EdfSignal:
             raise ValueError("Signal data not set")
         first_data_record = start_index // self.samples_per_data_record
         last_data_record = (end_index - 1) // self.samples_per_data_record + 1
-        try:
-            digital_portion = self._lazy_loader.load(
-                first_data_record, last_data_record
-            )
-        except InvalidRangeOfDataRecordsError as irdr:
-            raise ValueError("Invalid slice: Slice exceeds EDF duration") from irdr
+        digital_portion = self._lazy_loader.load(first_data_record, last_data_record)
         offset_within_first_record = start_index % self.samples_per_data_record
         num_samples = end_index - start_index
         return digital_portion[

--- a/edfio/edf_signal.py
+++ b/edfio/edf_signal.py
@@ -350,11 +350,11 @@ class EdfSignal:
         """
         return self._calibrate(self.digital)
 
-    def get_slice(
+    def get_digital_slice(
         self, start_second: float, duration: float
-    ) -> npt.NDArray[np.float64]:
+    ) -> npt.NDArray[np.int16]:
         """
-        Get a slice of the signal data.
+        Get a slice of the digital signal values.
 
         If the signal has not been loaded into memory so far, only the requested slice will be read.
 
@@ -372,7 +372,7 @@ class EdfSignal:
         start_index = round(start_second * self.sampling_frequency)
         end_index = round((start_second + duration) * self.sampling_frequency)
         if self._digital is not None:
-            return self._calibrate(self._digital[start_index:end_index])
+            return self._digital[start_index:end_index]
         if self._lazy_loader is None:
             raise ValueError("Signal data not set")
         first_data_record = start_index // self.samples_per_data_record
@@ -385,11 +385,26 @@ class EdfSignal:
             raise ValueError("Invalid slice: Slice exceeds EDF duration") from e
         offset_within_first_record = start_index % self.samples_per_data_record
         num_samples = end_index - start_index
-        return self._calibrate(
-            digital_portion[
-                offset_within_first_record : offset_within_first_record + num_samples
-            ]
-        )
+        return digital_portion[
+            offset_within_first_record : offset_within_first_record + num_samples
+        ]
+
+    def get_data_slice(
+        self, start_second: float, duration: float
+    ) -> npt.NDArray[np.float64]:
+        """
+        Get a slice of the signal data.
+
+        If the signal has not been loaded into memory so far, only the requested slice will be read.
+
+        Parameters
+        ----------
+        start_second : float
+            The start of the slice in seconds.
+        duration : float
+            The duration of the slice in seconds.
+        """
+        return self._calibrate(self.get_digital_slice(start_second, duration))
 
     def update_data(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,27 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
+
+from edfio._lazy_loading import LazyLoader
 
 
 @pytest.fixture()
 def tmp_file(tmp_path: Path) -> Path:
     return tmp_path / "target.edf"
+
+
+@pytest.fixture()
+def buffered_lazy_loader() -> LazyLoader:
+    # Buffer of 4 raw EDF records containing 12 samples for the tested signal.
+    # Data for other signals is set to zero.
+    data_records = np.array(
+        [
+            [0, 0, 0, 1, 2, 3, 0, 0],
+            [0, 0, 0, 4, 5, 6, 0, 0],
+            [0, 0, 0, 7, 8, 9, 0, 0],
+            [0, 0, 0, 10, 11, 12, 0, 0],
+        ],
+        dtype=np.int16,
+    )
+    return LazyLoader(data_records, 3, 6)

--- a/tests/test_edf.py
+++ b/tests/test_edf.py
@@ -1174,7 +1174,6 @@ def test_sampling_frequencies_leading_to_floating_point_issues_in_signal_duratio
         (0,              11,                  "EDF header indicates 11 data records, but file contains 10 records. Updating header."),
     ],
 )
-# fmt: on
 def test_read_edf_with_invalid_number_of_records(
     tmp_path: Path,
     extra_bytes: int,
@@ -1197,11 +1196,14 @@ def test_read_edf_with_invalid_number_of_records(
         comparison_edf = read_edf(EDF_FILE)
         for signal, comparison_signal in zip(edf.signals, comparison_edf.signals):
             np.testing.assert_array_equal(signal.data, comparison_signal.data)
+# fmt: on
 
 
 def test_fail_lazy_load():
     edf_data = EDF_FILE.read_bytes()
-    with pytest.raises(ValueError, match="Lazy loading is only supported for local file paths"):
+    with pytest.raises(
+        ValueError, match="Lazy loading is only supported for local file paths"
+    ):
         read_edf(edf_data, lazy_load_data=True)
 
 

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -475,4 +475,4 @@ def test_get_annotations_defined_in_timewindow():
         EdfAnnotation(7.8, 1, "D"),
     ]
     edf = Edf(signals=[EdfSignal(np.arange(10), 1)], annotations=all_annotations)
-    assert edf.get_annotations(3.4, 4.2) == tuple(all_annotations[1:3])
+    assert edf.get_annotations(0.9, 6.8) == tuple(all_annotations[1:3])

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -465,3 +465,14 @@ def test_add_annotations(tmp_file: Path):
     edf.write(tmp_file)
     edf = read_edf(tmp_file)
     assert edf.annotations == tuple(sorted(old_annotations + new_annotations))
+
+
+def test_get_annotations_defined_in_timewindow():
+    all_annotations = [
+        EdfAnnotation(0.15, 3, "A"),
+        EdfAnnotation(3.5, 1, "B"),
+        EdfAnnotation(5, 1, "C"),
+        EdfAnnotation(7.8, 1, "D"),
+    ]
+    edf = Edf(signals=[EdfSignal(np.arange(10), 1)], annotations=all_annotations)
+    assert edf.get_annotations(3.4, 4.2) == tuple(all_annotations[1:3])

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -475,4 +475,4 @@ def test_get_annotations_defined_in_timewindow():
         EdfAnnotation(7.8, 1, "D"),
     ]
     edf = Edf(signals=[EdfSignal(np.arange(10), 1)], annotations=all_annotations)
-    assert edf.get_annotations(0.9, 6.8) == tuple(all_annotations[1:3])
+    assert edf.get_annotations(0.9, 7.6) == tuple(all_annotations[1:3])

--- a/tests/test_edf_signal.py
+++ b/tests/test_edf_signal.py
@@ -46,7 +46,6 @@ from edfio.edf_signal import (
         (-1111111.5,    -1111112,         -1111112,         -1111111,),
     ],
 )
-# fmt: on
 def test_round_float_to_8_characters(
     value: float,
     expected_round: float,
@@ -56,6 +55,7 @@ def test_round_float_to_8_characters(
     assert _round_float_to_8_characters(value, round) == expected_round
     assert _round_float_to_8_characters(value, math.floor) == expected_floor
     assert _round_float_to_8_characters(value, math.ceil) == expected_ceil
+# fmt: on
 
 
 def sine(duration, f, fs):
@@ -371,7 +371,12 @@ def test_edf_signal_label_cannot_be_set_to_edf_annotations():
 
 
 def test_load_portion_of_signal_already_loaded():
-    signal = EdfSignal(np.arange(10), sampling_frequency=2, digital_range=(0, 9), physical_range=(0, 9))
+    signal = EdfSignal(
+        np.arange(10),
+        sampling_frequency=2,
+        digital_range=(0, 9),
+        physical_range=(0, 9),
+    )
     slice = signal.get_data_slice(1.5, 3)
     np.testing.assert_array_equal(slice, np.arange(3, 9))
 
@@ -407,12 +412,15 @@ def lazy_loaded_signal(buffered_lazy_loader: LazyLoader) -> EdfSignal:
         (1.33, 0.0),
     ],
 )
-def test_lazy_load_portion_of_signal(start: float, duration: float, lazy_loaded_signal: EdfSignal):
+def test_lazy_load_portion_of_signal(
+    start: float, duration: float, lazy_loaded_signal: EdfSignal
+):
     expected_digital_values = np.arange(1, 13, dtype=np.int16)
-    expected_digital_slice = expected_digital_values[round(start * 3) : round((start + duration) * 3)]
+    expected_digital_slice = expected_digital_values[
+        round(start * 3) : round((start + duration) * 3)
+    ]
     actual_digital_slice = lazy_loaded_signal.get_digital_slice(start, duration)
     np.testing.assert_array_equal(actual_digital_slice, expected_digital_slice)
-
 
     # Expected signal values for the slice.
     expected_data_slice = expected_digital_slice.astype(np.float64) / 10
@@ -429,7 +437,9 @@ def test_lazy_load_portion_of_signal(start: float, duration: float, lazy_loaded_
         (2.0, -1.0),
     ],
 )
-def test_lazy_load_portion_of_signal_outside_of_bounds(start: float, duration: float, lazy_loaded_signal: EdfSignal):
+def test_lazy_load_portion_of_signal_outside_of_bounds(
+    start: float, duration: float, lazy_loaded_signal: EdfSignal
+):
     with pytest.raises(ValueError, match="Invalid slice"):
         lazy_loaded_signal.get_data_slice(start, duration)
 

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -25,5 +25,5 @@ def test_load_some_records(buffered_lazy_loader: LazyLoader):
 def test_load_invalid_records(
     start_record: int, end_record: int, buffered_lazy_loader: LazyLoader
 ):
-    with pytest.raises(ValueError, match="Invalid specification of records to load"):
+    with pytest.raises(ValueError, match="Invalid slice: Slice exceeds EDF duration"):
         buffered_lazy_loader.load(start_record, end_record)

--- a/tests/test_lazy_loading.py
+++ b/tests/test_lazy_loading.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from edfio._lazy_loading import LazyLoader
+
+
+def test_load_entire_signal_data(buffered_lazy_loader: LazyLoader):
+    expected_data = np.arange(1, 13, dtype=np.int16)
+    np.testing.assert_array_equal(buffered_lazy_loader.load(), expected_data)
+
+
+def test_load_some_records(buffered_lazy_loader: LazyLoader):
+    expected_data = np.arange(4, 10, dtype=np.int16)
+    np.testing.assert_array_equal(buffered_lazy_loader.load(1, 3), expected_data)
+
+
+@pytest.mark.parametrize(
+    ("start_record", "end_record"),
+    [
+        (-1, 3),
+        (1, 5),
+        (3, 2),
+    ],
+)
+def test_load_invalid_records(
+    start_record: int, end_record: int, buffered_lazy_loader: LazyLoader
+):
+    with pytest.raises(ValueError, match="Invalid specification of records to load"):
+        buffered_lazy_loader.load(start_record, end_record)


### PR DESCRIPTION
Add methods to
- read raw data from a signal for a specified time window
- read EDF+ annotations for a specified time window