### PR TITLE
Use dependency groups for development dependencies and restructure the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,6 @@ name: Test
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,26 @@ concurrency:
 
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}-${{ hashFiles('pyproject.toml') }}
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+      - name: Pre-commit
+        run: uv run --python=3.9 --with numpy==1.22.0 pre-commit run --all-files
+
   test:
+    needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -35,17 +54,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           lfs: true
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
-      - name: Pre-commit
-        run: |
-          uv run --with ${{ matrix.numpy }} pre-commit run --all-files
       - name: Pytest
-        run: |
-          uv run --with ${{ matrix.numpy }} pytest -Werror --cov --cov-report term-missing --cov-fail-under=100
+        run: uv run --with ${{ matrix.numpy }} pytest -Werror --cov --cov-report term-missing --cov-fail-under=100

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Pre-commit
         run: |
-          uv run --extra dev --with ${{ matrix.numpy }} pre-commit run --all-files
+          uv run --with ${{ matrix.numpy }} pre-commit run --all-files
       - name: Pytest
         run: |
-          uv run --extra dev --with ${{ matrix.numpy }} pytest -Werror --cov --cov-report term-missing --cov-fail-under=100
+          uv run --with ${{ matrix.numpy }} pytest -Werror --cov --cov-report term-missing --cov-fail-under=100

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,7 +9,7 @@ build:
     python: "3.9"
   commands:
     - pip install uv
-    - uv run --extra dev python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
+    - uv run python -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs/source $READTHEDOCS_OUTPUT/html
 
 sphinx:
   configuration: docs/source/conf.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We suggest to use [`uv`](https://docs.astral.sh/uv/getting-started/installation/
 
 Create a virtual environment with Python 3.9 and install all dependencies:
 
-    uv sync --python=3.9 --all-extras
+    uv sync --python=3.9
 
 **When using `uv`, prepend the commands below with `uv run` to make sure they are executed in the virtual environment!**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dynamic = ["version"]
 [tool.hatch.build.targets.sdist]
 only-include = ["edfio"]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "pytest==7.4.3",
     "pytest-cov==4.1.0",


### PR DESCRIPTION
Since uv now supports [dependency groups](https://peps.python.org/pep-0735/) we can avoid our development dependencies being part of the project requirements published to e.g. PyPI.