### PR TITLE
ENH: Add BDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It requires Python>=3.9 and NumPy>=1.22 and is available on PyPI:
 - Slice recordings (by seconds or annotation texts)
 - Drop individual signals
 - Anonymize recordings
+- BDF file ([BioSemi](https://www.biosemi.com/faq/file_format.htm)) support
 
 
 ## Known limitations
@@ -38,7 +39,6 @@ It requires Python>=3.9 and NumPy>=1.22 and is available on PyPI:
 - The maximum data record size of 61440 bytes recommended by the [EDF specs](https://www.edfplus.info/specs/edf.html) is not enforced.
 - To write an EDF with a non-integer seconds duration, the data record duration has to be manually set to an appropriate value.
 - Slicing an EDF to a timespan that is not an integer multiple of the data record duration does not work.
-- BDF files ([BioSemi](https://www.biosemi.com/faq/file_format.htm)) are not supported.
 
 
 ## Contributing

--- a/edfio/_lazy_loading.py
+++ b/edfio/_lazy_loading.py
@@ -20,7 +20,7 @@ class LazyLoader:
 
     def __init__(
         self,
-        buffer: Union[NDArray[np.int16], np.memmap[Any, np.dtype[np.int16]]],
+        buffer: Union[NDArray[np.int16 | np.int32], np.memmap[Any, np.dtype[np.int16 | np.int32]]],
         start_sample: int,
         end_sample: int,
     ) -> None:
@@ -30,7 +30,7 @@ class LazyLoader:
 
     def load(
         self, start_record: Optional[int] = None, end_record: Optional[int] = None
-    ) -> NDArray[np.int16]:
+    ) -> NDArray[np.int16 | np.int32]:
         """
         Load signal data from the buffer.
 

--- a/edfio/edf_annotations.py
+++ b/edfio/edf_annotations.py
@@ -61,6 +61,7 @@ def _create_annotations_signal(
     data_record_duration: float,
     with_timestamps: bool = True,
     subsecond_offset: float = 0,
+    fmt: Literal["edf", "bdf"] = "edf",
 ) -> EdfSignal:
     data_record_starts = np.arange(num_data_records) * data_record_duration
     annotations = sorted(annotations)
@@ -92,7 +93,8 @@ def _create_annotations_signal(
     signal = EdfSignal(
         np.arange(1.0),  # placeholder signal, as argument `data` is non-optional
         sampling_frequency=maxlen // 2 / divisor,
-        physical_range=(-32768, 32767),
+        physical_range=(-32768, 32767) if fmt == "edf" else (-8388608, 8388607),
+        fmt=fmt,
     )
     signal._label = b"EDF Annotations "
     signal._set_samples_per_data_record(maxlen // 2)


### PR DESCRIPTION
Couldn't resist the temptation to try, didn't end up being too bad! Data reading now at least seems to work in [MNE-Python](https://github.com/mne-tools/mne-python/pull/13091) and I "just" have some work to do to get the annotations working properly for our tests at least. Then hopefully it's not too much work to fix the rest here.

One tricky part will be supporting memmaps, but I'd be inclined to simply not support them for BDF data for now. Someone else could always add it later!

- [ ] Fix annotation support
- [ ] Disallow memmaps for BDF
- [ ] Add tests

Closes #62