### PR TITLE
Allow having annotations with and without durations in the same recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix annotations with None duration raise exceptions ([#67](https://github.com/the-siesta-group/edfio/pull/67)) ([JohnAtl](https://github.com/JohnAtl))
 
 ## [0.4.6] - 2025-02-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-- Fix annotations with None duration raise exceptions ([#67](https://github.com/the-siesta-group/edfio/pull/67)) ([JohnAtl](https://github.com/JohnAtl))
+
+### Fixed
+- Allow having annotations with and without durations in the same recording ([#67](https://github.com/the-siesta-group/edfio/pull/67)) ([JohnAtl](https://github.com/JohnAtl))
 
 ## [0.4.6] - 2025-02-27
 

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -820,7 +820,10 @@ class Edf:
             )
             for ann in annotations
         ]
-        annotations = sorted(annotations)
+        annotations = sorted(
+            annotations,
+            key=lambda ann: (ann.onset, ann.duration is None, ann.duration if ann.duration is not None else 0),
+        )
         if start_second_defined:
             while annotations and annotations[0].onset < start_second:
                 annotations.pop(0)

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -820,10 +820,7 @@ class Edf:
             )
             for ann in annotations
         ]
-        annotations = sorted(
-            annotations,
-            key=lambda ann: (ann.onset, ann.duration is None, ann.duration if ann.duration is not None else 0),
-        )
+        annotations = sorted(annotations)
         if start_second_defined:
             while annotations and annotations[0].onset < start_second:
                 annotations.pop(0)

--- a/edfio/edf_annotations.py
+++ b/edfio/edf_annotations.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -52,6 +52,19 @@ class EdfAnnotation(NamedTuple):
     onset: float
     duration: float | None
     text: str
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, EdfAnnotation):
+            return NotImplemented
+        return (
+            self.onset,
+            -1 if self.duration is None else self.duration,
+            self.text,
+        ) < (
+            other.onset,
+            -1 if other.duration is None else other.duration,
+            other.text,
+        )
 
 
 def _create_annotations_signal(

--- a/edfio/edf_annotations.py
+++ b/edfio/edf_annotations.py
@@ -55,7 +55,7 @@ class EdfAnnotation(NamedTuple):
 
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, EdfAnnotation):
-            return NotImplemented
+            return NotImplemented  # pragma: no cover
         return (
             self.onset,
             -1 if self.duration is None else self.duration,

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -476,3 +476,20 @@ def test_get_annotations_defined_in_timewindow():
     ]
     edf = Edf(signals=[EdfSignal(np.arange(10), 1)], annotations=all_annotations)
     assert edf.get_annotations(0.9, 7.6) == tuple(all_annotations[1:3])
+
+
+def test_mixture_of_annotations_with_and_without_durations():
+    annotations = (
+        EdfAnnotation(0.2, 0.5, "B"),
+        EdfAnnotation(0.1, 0, "A"),
+        EdfAnnotation(0.1, None, "A"),
+        EdfAnnotation(0.7, None, "C"),
+    )
+    edf = Edf([], annotations=annotations)
+    edf = read_edf(edf.to_bytes())
+    assert edf.annotations == (
+        EdfAnnotation(0.1, None, "A"),
+        EdfAnnotation(0.1, 0, "A"),
+        EdfAnnotation(0.2, 0.5, "B"),
+        EdfAnnotation(0.7, None, "C"),
+    )


### PR DESCRIPTION
Data from one of our customers have duration for some annotations set to None, which causes sorted to raise an exception when trying to access the annotations due to the call to sorted in get_annotations.
Added a lambda expression to use 0 instead of None as the duration when sorting.
