### PR TITLE
Fix support latin characters in fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+### Added
+- Add a parameter `header_encoding="ascii"` to `read_edf()` to support reading header fields that use a character encoding different to ascii ([#68](https://github.com/the-siesta-group/edfio/pull/68)) ([JohnAtl](https://github.com/JohnAtl))
+
 ### Fixed
-- Support latin characters in fields ([#68](https://github.com/the-siesta-group/edfio/pull/68)) ([JohnAtl](https://github.com/JohnAtl))
+- Use ascii instead of utf-8 as the default character encoding for reading header fields ([#68](https://github.com/the-siesta-group/edfio/pull/68)) ([JohnAtl](https://github.com/JohnAtl))
 
 ## [0.4.7] - 2025-03-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Support latin characters in fields ([#68](https://github.com/the-siesta-group/edfio/pull/68)) ([JohnAtl](https://github.com/JohnAtl))
+
 ## [0.4.7] - 2025-03-21
 
 ### Fixed

--- a/edfio/_header_field.py
+++ b/edfio/_header_field.py
@@ -28,8 +28,8 @@ def encode_str(value: str, length: int) -> bytes:
     return value.encode("ascii").ljust(length)
 
 
-def decode_str(field: bytes) -> str:
-    return field.decode("latin-1", errors="replace").rstrip()
+def decode_str(field: bytes, encoding: str = "ascii") -> str:
+    return field.decode(encoding=encoding, errors="replace").rstrip()
 
 
 def encode_int(value: int, length: int) -> bytes:

--- a/edfio/_header_field.py
+++ b/edfio/_header_field.py
@@ -29,7 +29,7 @@ def encode_str(value: str, length: int) -> bytes:
 
 
 def decode_str(field: bytes) -> str:
-    return field.decode(errors="replace").rstrip()
+    return field.decode("latin-1", errors="replace").rstrip()
 
 
 def encode_int(value: int, length: int) -> bytes:

--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -142,6 +142,7 @@ class Edf:
             )
             self._set_reserved("EDF+C")
         self._set_signals(signals)
+        self._header_encoding = "ascii"
 
     def __repr__(self) -> str:
         signals_text = f"{len(self.signals)} signal"
@@ -184,7 +185,7 @@ class Edf:
         --------
         patient: Parsed representation, as a :class:`Patient` object.
         """
-        return decode_str(self._local_patient_identification)
+        return decode_str(self._local_patient_identification, self._header_encoding)
 
     @local_patient_identification.setter
     def local_patient_identification(self, value: str) -> None:
@@ -199,7 +200,7 @@ class Edf:
         --------
         recording: Parsed representation, as a :class:`Recording` object.
         """
-        return decode_str(self._local_recording_identification)
+        return decode_str(self._local_recording_identification, self._header_encoding)
 
     @local_recording_identification.setter
     def local_recording_identification(self, value: str) -> None:
@@ -252,11 +253,16 @@ class Edf:
             else:
                 signal._digital = datarecords[:, start:end].flatten()
 
-    def _read_header(self, buffer: io.BufferedReader | io.BytesIO) -> None:
+    def _read_header(
+        self,
+        buffer: io.BufferedReader | io.BytesIO,
+        header_encoding: str,
+    ) -> None:
+        self._header_encoding = header_encoding
         for header_name, length in Edf._header_fields:
             setattr(self, "_" + header_name, buffer.read(length))
         self._signals = self._parse_signal_headers(
-            buffer.read(256 * self._total_num_signals)
+            buffer.read(256 * self._total_num_signals), header_encoding
         )
 
     @property
@@ -304,7 +310,11 @@ class Edf:
                 )
         self._set_num_data_records(num_data_records)
 
-    def _parse_signal_headers(self, raw_signal_headers: bytes) -> tuple[EdfSignal, ...]:
+    def _parse_signal_headers(
+        self,
+        raw_signal_headers: bytes,
+        header_encoding: str,
+    ) -> tuple[EdfSignal, ...]:
         raw_headers_split: dict[str, list[bytes]] = {}
         start = 0
         for header_name, length in EdfSignal._header_fields:
@@ -328,7 +338,11 @@ class Edf:
                 if raw_signal_header["label"].rstrip() == b"EDF Annotations":
                     sampling_frequency = 0
             signals.append(
-                EdfSignal._from_raw_header(sampling_frequency, **raw_signal_header)
+                EdfSignal._from_raw_header(
+                    sampling_frequency,
+                    **raw_signal_header,
+                    header_encoding=header_encoding,
+                )
             )
         return tuple(signals)
 
@@ -1091,31 +1105,39 @@ def _calculate_data_record_duration(signals: Sequence[EdfSignal]) -> float:
 
 
 @singledispatch
-def _read_edf(edf_file: Any, *, lazy_load_data: bool) -> Edf:
+def _read_edf(edf_file: Any, *, lazy_load_data: bool, header_encoding: str) -> Edf:
     edf = object.__new__(Edf)
-    edf._read_header(edf_file)
+    edf._read_header(edf_file, header_encoding)
     edf._load_data(edf_file, lazy_load_data=lazy_load_data)
     return edf
 
 
 @_read_edf.register
-def _(edf_file: Path, *, lazy_load_data: bool) -> Edf:
+def _(edf_file: Path, *, lazy_load_data: bool, header_encoding: str) -> Edf:
     edf = object.__new__(Edf)
     edf_file = edf_file.expanduser()
     with edf_file.open("rb") as file:
-        edf._read_header(file)
+        edf._read_header(file, header_encoding)
     edf._load_data(edf_file, lazy_load_data=lazy_load_data)
     return edf
 
 
 @_read_edf.register
-def _(edf_file: str, *, lazy_load_data: bool) -> Edf:
-    return _read_edf(Path(edf_file), lazy_load_data=lazy_load_data)
+def _(edf_file: str, *, lazy_load_data: bool, header_encoding: str) -> Edf:
+    return _read_edf(
+        Path(edf_file),
+        lazy_load_data=lazy_load_data,
+        header_encoding=header_encoding,
+    )
 
 
 @_read_edf.register
-def _(edf_file: bytes, *, lazy_load_data: bool) -> Edf:
-    return _read_edf(io.BytesIO(edf_file), lazy_load_data=lazy_load_data)
+def _(edf_file: bytes, *, lazy_load_data: bool, header_encoding: str) -> Edf:
+    return _read_edf(
+        io.BytesIO(edf_file),
+        lazy_load_data=lazy_load_data,
+        header_encoding=header_encoding,
+    )
 
 
 # Pyright loses information about parameters for singledispatch functions. Hiding it
@@ -1128,6 +1150,8 @@ def read_edf(
     | bytes
     | tempfile.SpooledTemporaryFile[bytes],
     lazy_load_data: bool | Literal["auto"] = "auto",
+    *,
+    header_encoding: str = "ascii",
 ) -> Edf:
     """
     Read an EDF file into an :class:`Edf` object.
@@ -1142,6 +1166,8 @@ def read_edf(
         If `True`, the raw signal data is not loaded into memory until it is accessed. If `False`,
         the data is loaded immediately. If `"auto"`, the data is loaded lazily if
         the specified edf_file represents a local path and eagerly otherwise.
+    header_encoding : str, default: "ascii"
+        The character encoding to use when reading header fields.
 
     Returns
     -------
@@ -1150,4 +1176,8 @@ def read_edf(
     """
     if lazy_load_data == "auto":
         lazy_load_data = isinstance(edf_file, (Path, str))
-    return _read_edf(edf_file, lazy_load_data=lazy_load_data)
+    return _read_edf(
+        edf_file,
+        lazy_load_data=lazy_load_data,
+        header_encoding=header_encoding,
+    )

--- a/edfio/edf_header.py
+++ b/edfio/edf_header.py
@@ -114,7 +114,6 @@ class Patient:
 
     @classmethod
     def _from_str(cls, string: str) -> Patient:
-        encode_str(string, 80)
         obj = object.__new__(cls)
         obj._local_patient_identification = string
         return obj
@@ -228,7 +227,6 @@ class Recording:
 
     @classmethod
     def _from_str(cls, string: str) -> Recording:
-        encode_str(string, 80)
         obj = object.__new__(cls)
         obj._local_recording_identification = string
         return obj

--- a/edfio/edf_signal.py
+++ b/edfio/edf_signal.py
@@ -125,6 +125,7 @@ class EdfSignal:
         self._set_physical_range(physical_range, data)
         self._set_digital_range(digital_range)
         self._set_data(data)
+        self._header_encoding = "ascii"
 
     def __repr__(self) -> str:
         info = f"{self.sampling_frequency:g}Hz"
@@ -147,6 +148,7 @@ class EdfSignal:
         prefiltering: bytes,
         samples_per_data_record: bytes,
         reserved: bytes,
+        header_encoding: str = "ascii",
     ) -> EdfSignal:
         sig = object.__new__(cls)
         sig._sampling_frequency = sampling_frequency
@@ -160,6 +162,7 @@ class EdfSignal:
         sig._prefiltering = prefiltering
         sig._samples_per_data_record = samples_per_data_record
         sig._reserved = reserved
+        sig._header_encoding = header_encoding
         return sig
 
     @classmethod
@@ -215,7 +218,7 @@ class EdfSignal:
     @property
     def label(self) -> str:
         """Signal label, e.g., `"EEG Fpz-Cz"` or `"Body temp"`."""
-        return decode_str(self._label)
+        return decode_str(self._label, self._header_encoding)
 
     @label.setter
     def label(self, label: str) -> None:
@@ -226,7 +229,7 @@ class EdfSignal:
     @property
     def transducer_type(self) -> str:
         """Transducer type, e.g., `"AgAgCl electrode"`."""
-        return decode_str(self._transducer_type)
+        return decode_str(self._transducer_type, self._header_encoding)
 
     @transducer_type.setter
     def transducer_type(self, transducer_type: str) -> None:
@@ -235,7 +238,7 @@ class EdfSignal:
     @property
     def physical_dimension(self) -> str:
         """Physical dimension, e.g., `"uV"` or `"degreeC`."""
-        return decode_str(self._physical_dimension)
+        return decode_str(self._physical_dimension, self._header_encoding)
 
     @physical_dimension.setter
     def physical_dimension(self, physical_dimension: str) -> None:
@@ -264,7 +267,7 @@ class EdfSignal:
     @property
     def prefiltering(self) -> str:
         """Signal prefiltering, e.g., `"HP:0.1Hz LP:75Hz"`."""
-        return decode_str(self._prefiltering)
+        return decode_str(self._prefiltering, self._header_encoding)
 
     @prefiltering.setter
     def prefiltering(self, prefiltering: str) -> None:

--- a/tests/test_edf_header.py
+++ b/tests/test_edf_header.py
@@ -134,9 +134,9 @@ def test_patient_raises_error_if_too_long_for_header_field():
         Patient(code="X" * 81)
 
 
-def test_patient_from_str_raises_error_if_too_long_for_header_field():
+def test_local_patient_identification_raises_error_if_too_long_for_header_field(edf):
     with pytest.raises(ValueError, match="exceeds maximum field length"):
-        Patient._from_str("X" * 81)
+        edf.local_patient_identification = "X" * 81
 
 
 def test_patient_raises_error_on_invalid_characters():
@@ -144,9 +144,9 @@ def test_patient_raises_error_on_invalid_characters():
         Patient(name="ÄÖÜ")
 
 
-def test_patient_from_str_raises_error_on_invalid_characters():
+def test_local_patient_identification_raises_error_on_invalid_characters(edf):
     with pytest.raises(UnicodeEncodeError, match="'ascii' codec can't encode"):
-        Patient._from_str("X X X AÖÜ")
+        edf.local_patient_identification = "X X X ÄÖÜ"
 
 
 def test_recording_from_str(recording: Recording):
@@ -240,9 +240,9 @@ def test_recording_raises_error_if_too_long_for_header_field():
         Recording(equipment_code="X" * 81)
 
 
-def test_recording_from_str_raises_error_if_too_long_for_header_field():
+def test_local_recording_identification_raises_error_if_too_long_for_header_field(edf):
     with pytest.raises(ValueError, match="exceeds maximum field length"):
-        Recording._from_str("X" * 81)
+        edf.local_recording_identification = "X" * 81
 
 
 def test_recording_raises_error_on_invalid_characters():
@@ -250,9 +250,9 @@ def test_recording_raises_error_on_invalid_characters():
         Recording(investigator_technician_code="ÄÖÜ")
 
 
-def test_recording_from_str_raises_error_on_invalid_characters():
+def test_local_recording_identification_raises_error_on_invalid_characters(edf):
     with pytest.raises(UnicodeEncodeError, match="'ascii' codec can't encode"):
-        Recording._from_str("Startdate X ÄÖÜ X X")
+        edf.local_recording_identification = "Startdate X ÄÖÜ X X"
 
 
 def test_setting_edf_recording_with_new_startdate_changes_both_startdate_fields():

--- a/tests/test_header_field.py
+++ b/tests/test_header_field.py
@@ -32,9 +32,12 @@ def test_encode_float(value: float, expected: bytes):
     assert encode_float(value) == expected
 
 
-def test_decode_str():
+def test_decode_str_replaces_non_ascii_characters():
     assert decode_str("è".encode("latin-1")) == "�"
-    assert decode_str("è".encode()) == "è"
+
+
+def test_decode_str_with_latin_1_encoding():
+    assert decode_str("è".encode("latin-1"), "latin-1") == "è"
 
 
 @pytest.mark.parametrize("field", [b"1E2345  ", b"-1E2345 "])


### PR DESCRIPTION
Latin characters in fields such as label, such as "Cânula", and "Posição" are not interpreted as `latin-1`, and become "C�nula", "Posi��o".
