### PR TITLE
ENH: Add progress bar to slice between seconds

### DIFF
--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -14,6 +14,7 @@ from fractions import Fraction
 from math import ceil, floor
 from pathlib import Path
 from typing import ClassVar, Generic, Literal, TypeVar, Union
+from tqdm import tqdm
 
 import numpy as np
 
@@ -981,7 +982,7 @@ class _Base(Generic[_Signal]):
         self._verify_seconds_coincide_with_sample_time(start)
         self._verify_seconds_coincide_with_sample_time(stop)
         self._set_num_data_records(int((stop - start) / self.data_record_duration))
-        for signal in self._signals:
+        for signal in tqdm(self._signals):
             if signal._is_annotation_signal:
                 signals.append(
                     self._slice_annotations_signal(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
     "numpy >= 1.22.0",
+    "tqdm>=4.67.1",
     "typing_extensions >= 4.0.0; python_version < '3.11'",
 ]
 classifiers = [


### PR DESCRIPTION
I have a 20 GB file and I want to take clips out of it. I'm surprised this process is so slow:

```
Initializing
Cropping between 20572.00006235294 and 20811.354776470587
  5%|███▊                                                                             | 6/129 [01:33<31:53, 15.55s/it]
```

so there are probably ways to speed this up but a progress bar at least gives some estimation.

I didn't see the concept of ``verbose`` which might be nice to be able to turn it off. It took me like 1 minute so if you'd rather not, no worries. Perhaps would be better if ``verbose`` was added as well but that's a bigger change and I don't want to make something without discussing.