### PR TITLE
BUG: Allow float sfreq

### DIFF
--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -49,6 +49,7 @@ else:  # pragma: no cover
 
 
 _Signal = TypeVar("_Signal", bound=Union[EdfSignal, BdfSignal])
+ABSOLUTE_TOLERANCE = 1e-8  # for rounding to seconds * sampling_frequency to samples
 
 
 class _Base(Generic[_Signal]):
@@ -1051,7 +1052,7 @@ class _Base(Generic[_Signal]):
     def _verify_seconds_coincide_with_sample_time(self, seconds: float) -> None:
         for i, signal in enumerate(self.signals):
             index = seconds * signal.sampling_frequency
-            if index != int(index):
+            if abs(index - round(index)) > ABSOLUTE_TOLERANCE:
                 raise ValueError(
                     f"{seconds}s is not a sample time of signal {i} ({signal.label}) with fs={signal.sampling_frequency}Hz"
                 )
@@ -1194,7 +1195,9 @@ def _calculate_num_data_records(
         )
     for f in (lambda x: x, lambda x: Decimal(str(x))):
         required_num_data_records = f(signal_duration) / f(data_record_duration)
-        if np.isclose(required_num_data_records, round(required_num_data_records), atol=1e-10):
+        if abs(required_num_data_records - f(round(required_num_data_records))) <= f(
+            ABSOLUTE_TOLERANCE
+        ):
             return round(required_num_data_records)
     raise ValueError(
         f"_Signal duration of {signal_duration}s is not exactly divisible by data_record_duration of {data_record_duration}s"


### PR DESCRIPTION
For a data file I have with `fs=999.4121105232217Hz`, it is not possible to simultaneously satisfy the integer multiple of record duration and integer samples constraints, I either get


```
ValueError: 20812.045182352966s is not a sample time of signal 0 (Event) with fs=999.4121105232217Hz
```

or

```
ValueError: _Signal duration of 240.04511999999886s is not exactly divisible by data_record_duration of 0.23814s
```

even when I find a multiple of both because of floating point precision.

This relaxes the precision very slightly to account for these differences. I was going to use ``np.finfo(float).eps`` but empirically, the difference was

```
(required_num_data_records - round(required_num_data_records))
np.float64(-4.774847184307873e-12)
```

so I went with ``1e-10`` to be close to that with a bit of leeway.