### PR TITLE
ENH: allow joblib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = [
+    "joblib>=1.5.2",
     "numpy >= 1.22.0",
     "typing_extensions >= 4.0.0; python_version < '3.11'",
 ]


### PR DESCRIPTION
Fixes #91.

Well it was taking so long to clip my file (the process got killed once too) that I ended up implementing this. It got my runtime down from 30 minutes to 1.5 minutes (with 16 cores).

You've all done such a good job keeping the dependencies absolutely minimal I feel bad adding joblib but I added it in a way that it could be optional. If you want to add this, let me know and I'll can change it so that you only install joblib if you do `pip install edfio[extras]` or something like that. Or it can be a full dependency or we can close, just let me know.