### PR TITLE
Avoid reading from disk in EdfSignal._num_samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## Changed
+- Avoid loading data from disk when creating a new `Edf` object based on signals from an existing file ([#98](https://github.com/the-siesta-group/edfio/pull/98))
+
 ## [0.4.11] - 2025-11-19
 
 ### Fixed


### PR DESCRIPTION
When instantiating a new `Edf` object, we retrieve the number of samples of each signal to calculate the required number of data records. If those signals come from a file that was opened with lazy loading enabled, we currently load the data  just for that (via `EdfSignal._num_samples` and `EdfSignal.digital`). This PR uses the shape of the memmap without loading the data.