### PR TITLE
BUG: Fix precision error when adding annotations

### DIFF
--- a/edfio/edf.py
+++ b/edfio/edf.py
@@ -329,7 +329,7 @@ class _Base(Generic[_Signal]):
             num_data_records = 1
         else:
             signal_durations = [
-                round(s._num_samples / s.sampling_frequency, 12) for s in signals
+                round(s._num_samples / s.sampling_frequency, 9) for s in signals
             ]
             if any(v != signal_durations[0] for v in signal_durations[1:]):
                 raise ValueError(
@@ -581,7 +581,7 @@ class _Base(Generic[_Signal]):
                 ):
                     ann_dr = _EdfAnnotationsDataRecord.from_bytes(data_record.tobytes())
                     for tal in ann_dr.tals:
-                        tal.onset = round(tal.onset + onset_change, 12)
+                        tal.onset = round(tal.onset + onset_change, 9)
                     data_records.append(ann_dr.to_bytes())
                 maxlen = max(len(data_record) for data_record in data_records)
                 maxlen = math.ceil(maxlen / bytes_per_sample) * bytes_per_sample
@@ -916,7 +916,7 @@ class _Base(Generic[_Signal]):
         subsecond_offset = self._subsecond_offset
         annotations = [
             EdfAnnotation(
-                round(ann.onset - subsecond_offset, 12), ann.duration, ann.text
+                round(ann.onset - subsecond_offset, 9), ann.duration, ann.text
             )
             for ann in annotations
         ]
@@ -1157,7 +1157,7 @@ class _Base(Generic[_Signal]):
             else:
                 annotations.extend(annot_dr.annotations)
         annotations = [
-            EdfAnnotation(round(a.onset - start, 12), a.duration, a.text)
+            EdfAnnotation(round(a.onset - start, 9), a.duration, a.text)
             for a in annotations
             if keep_all_annotations or start <= a.onset < stop
         ]


### PR DESCRIPTION
I wasn't able to add an event to an edf with a non-integer (sampling frequency 999.4121105232217 Hz) as shown in the stack trace below. I just toned down the rounding to 9 digits and it worked. I went ahead and applied that everywhere for consistency. Not sure if you want to accept but it's a pain getting these kinds of errors.

Note the very last signal duration for the annotations channel being very slightly different at the end of the last line of the error message.

```
In [10]: raw.add_annotations([edfio.EdfAnnotation(onset=8328.35115, duration=0.1, text="fake event")])
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[10], line 1
----> 1 raw.add_annotations([edfio.EdfAnnotation(onset=8328.35115, duration=0.1, text="fake event")])

File ~/.venv/lib/python3.14/site-packages/edfio/edf.py:997, in _Base.add_annotations(self, annotations)
    985 def add_annotations(self, annotations: Iterable[EdfAnnotation]) -> None:
    986     """
    987     Add annotations to the Edf.
    988 
   (...)    995         The annotations to add.
    996     """
--> 997     self.set_annotations(self.annotations + tuple(annotations))

File ~/.venv/lib/python3.14/site-packages/edfio/edf.py:983, in _Base.set_annotations(self, annotations)
    964 """
    965 Overwrite all annotations with new ones.
    966 
   (...)    973     The annotations to set.
    974 """
    975 new_annotation_signal = _create_annotations_signal(
    976     annotations,
    977     num_data_records=self.num_data_records,
   (...)    981     subsecond_offset=self.starttime.microsecond / 1_000_000,
    982 )
--> 983 self._set_signals((*self.signals, new_annotation_signal))

File ~/.venv/lib/python3.14/site-packages/edfio/edf.py:317, in _Base._set_signals(self, signals)
    313     if type(signal) is not self._signal_class:
    314         raise ValueError(
    315             f"_Signal {si} ({signal}) has format {signal._fmt}, but recording is {self._fmt}"
    316         )
--> 317 self._set_num_data_records_with_signals(signals)
    318 self._signals = signals
    319 self._set_bytes_in_header_record(256 * (len(signals) + 1))

File ~/.venv/lib/python3.14/site-packages/edfio/edf.py:335, in _Base._set_num_data_records_with_signals(self, signals)
    331 signal_durations = [
    332     round(s._num_samples / s.sampling_frequency, 12) for s in signals
    333 ]
    334 if any(v != signal_durations[0] for v in signal_durations[1:]):
--> 335     raise ValueError(
    336         f"Inconsistent signal durations (in seconds): {signal_durations}"
    337     )
    338 num_data_records = _calculate_num_data_records(
    339     signal_durations[0],
    340     self.data_record_duration,
    341 )
    342 signal_lengths = [s._num_samples for s in signals]

ValueError: Inconsistent signal durations (in seconds): [16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.702299999997, 16656.7023]
```