### PR TITLE
Re-enable PR pipelines but try to prevent duplicates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,9 @@
 name: Test
 
 on:
-  push:
-    paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
+  workflow_dispatch:
   workflow_call:
+  pull_request:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
I think [this change](https://github.com/the-siesta-group/edfio/commit/cfd6314eb1731d38cc0136071bebcdcd6fb9abb8#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-L11) in #106 will cause pipelines to be not shown as checks in PRs from forks. To still avoid duplicate pipelines, while keeping the ability to run the test workflow without needing to create a PR, I think the best way is to allow manual triggers instead of push triggers.