### PR TITLE
Fix binary rounding noise in annotation onset/duration encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Encode annotation onsets and durations using the shortest round-trippable decimal, avoiding binary rounding noise that corrupted the sub-second start offset of long EDF+ recordings and made them unreadable by strict EDF+ readers ([#109](https://github.com/the-siesta-group/edfio/pull/109)).
+
 ## [0.4.14] - 2026-07-15
 
 ### Added

--- a/edfio/edf_annotations.py
+++ b/edfio/edf_annotations.py
@@ -22,19 +22,19 @@ _ANNOTATIONS_PATTERN = re.compile(
 
 
 def _encode_annotation_onset(onset: float) -> str:
-    string = f"{onset:+.12f}".rstrip("0")
-    if string[-1] == ".":
-        return string[:-1]
-    return string
+    # Use the shortest decimal string that round-trips to the same float, in
+    # positional (non-scientific) notation as required by EDF+. A fixed-precision
+    # format such as f"{onset:+.12f}" exposes binary rounding noise once the
+    # integer part is large (e.g. 8192.202312 -> "+8192.202311999999"), producing
+    # an onset that drifts from the intended sub-second offset and is rejected by
+    # strict EDF+ readers.
+    return np.format_float_positional(onset, unique=True, trim="-", sign=True)
 
 
 def _encode_annotation_duration(duration: float) -> str:
     if duration < 0:
         raise ValueError(f"Annotation duration must be positive, is {duration}")
-    string = f"{duration:.12f}".rstrip("0")
-    if string[-1] == ".":
-        return string[:-1]
-    return string
+    return np.format_float_positional(duration, unique=True, trim="-")
 
 
 class EdfAnnotation(NamedTuple):

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -101,7 +101,8 @@ def test_long_recording_with_subsecond_starttime_roundtrip(tmp_file: Path):
     # corrupting the sub-second offset. Ensure the offset round-trips exactly.
     duration_s = 8193
     starttime = datetime.time(23, 20, 20, 202312)
-    edf = Edf([EdfSignal(np.zeros(duration_s), 1)], starttime=starttime)
+    with pytest.warns(UserWarning, match="Creating [BE]DF\\+C to store microsecond"):
+        edf = Edf([EdfSignal(np.zeros(duration_s), 1)], starttime=starttime)
     edf.write(tmp_file)
     edf = read_edf(tmp_file)
     assert edf.starttime == starttime

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -103,7 +103,11 @@ def test_long_recording_with_subsecond_starttime_roundtrip(tmp_file: Path):
     starttime = datetime.time(23, 20, 20, 202312)
     edf = Edf([EdfSignal(np.zeros(duration_s), 1)], starttime=starttime)
     edf.write(tmp_file)
-    assert read_edf(tmp_file).starttime == starttime
+    edf = read_edf(tmp_file)
+    assert edf.starttime == starttime
+    signal = edf._signals[1]
+    last_data_record = signal.digital.reshape(-1, signal._bytes_per_data_record)[-1]
+    assert last_data_record.tobytes().startswith(b"+8192.202312")
 
 
 def test_edf_annotations():

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -52,6 +52,12 @@ MNE_TEST_ANNOTATIONS = (
         (0.00000001, "+0.00000001"),
         (0.00000000001, "+0.00000000001"),
         (100000000000.0, "+100000000000"),
+        # onsets whose fixed-precision formatting would expose binary rounding
+        # noise once the integer part is large (see GitHub issue)
+        (8191.202312, "+8191.202312"),
+        (8192.202312, "+8192.202312"),
+        (8193.202312, "+8193.202312"),
+        (29787.202312, "+29787.202312"),
         (-0.1, "-0.1"),
         (-0.0000001, "-0.0000001"),
         (-0.0000000001, "-0.0000000001"),
@@ -76,6 +82,7 @@ def test_encode_annotation_onset(onset: float, expected: str):
         (0.0000001, "0.0000001"),
         (0.00000000001, "0.00000000001"),
         (100000000000.0, "100000000000"),
+        (12345.6789, "12345.6789"),
     ],
 )
 def test_encode_annotation_duration(duration: float, expected: str):
@@ -85,6 +92,18 @@ def test_encode_annotation_duration(duration: float, expected: str):
 def test_encode_annotation_duration_raises_error_for_negative_values():
     with pytest.raises(ValueError, match="Annotation duration must be positive, is"):
         _encode_annotation_duration(-1)
+
+
+def test_long_recording_with_subsecond_starttime_roundtrip(tmp_file: Path):
+    # A sub-second starttime writes a timekeeping onset into every data record.
+    # For long recordings the later onsets have a large integer part, which used
+    # to expose binary rounding noise (e.g. 8192.202312 -> "+8192.202311999999"),
+    # corrupting the sub-second offset. Ensure the offset round-trips exactly.
+    duration_s = 8193
+    starttime = datetime.time(23, 20, 20, 202312)
+    edf = Edf([EdfSignal(np.zeros(duration_s), 1)], starttime=starttime)
+    edf.write(tmp_file)
+    assert read_edf(tmp_file).starttime == starttime
 
 
 def test_edf_annotations():

--- a/tests/test_edf_annotations.py
+++ b/tests/test_edf_annotations.py
@@ -53,7 +53,7 @@ MNE_TEST_ANNOTATIONS = (
         (0.00000000001, "+0.00000000001"),
         (100000000000.0, "+100000000000"),
         # onsets whose fixed-precision formatting would expose binary rounding
-        # noise once the integer part is large (see GitHub issue)
+        # noise once the integer part is large (see GitHub issue #109)
         (8191.202312, "+8191.202312"),
         (8192.202312, "+8192.202312"),
         (8193.202312, "+8193.202312"),


### PR DESCRIPTION
A sub-second start time writes a timekeeping onset into every EDF+ data record. For long recordings the later onsets have a large integer part, so the fixed-precision format f"{onset:+.12f}" exposed binary rounding noise (e.g. 8192.202312 -> "+8192.202311999999"). This corrupts the encoded sub-second offset and makes the file unreadable by strict EDF+ readers such as edflib/pyedflib, even though the file is otherwise valid.

Encode onsets and durations with np.format_float_positional(unique=True), which yields the shortest decimal string that round-trips to the same float in positional notation, avoiding both the rounding noise and the resulting over-wide annotation records.

fixes #109 