### PR TITLE
Support scm versioning from git archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=[0-9]*)$
+ref-names: $Format:%D$

--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,4 @@
 node: $Format:%H$
 node-date: $Format:%cI$
-describe-name: $Format:%(describe:tags=true,match=[0-9]*)$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
 ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
With this you can `pip install https://...` blobs instead of `pip install git+` whole-repo clones (see for example the two lines [here](https://github.com/mne-tools/mne-python/blob/1f8ce92ab1ad6409f7b4a7c6ac9fec85017d4be9/tools/install_pre_requirements.sh#L57-L58)). Been using it with MNE-Python for a while now and have had no issues.